### PR TITLE
Change client methods accessibility to public

### DIFF
--- a/lib/GotenbergSharpClient.cs
+++ b/lib/GotenbergSharpClient.cs
@@ -163,7 +163,16 @@ namespace Gotenberg.Sharp.API.Client
 
         #region exec
 
-        async Task<Stream> ExecuteRequestAsync(IApiRequest request, CancellationToken cancelToken)
+        /// <summary>
+        /// Support custom request type
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="cancelToken"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        [PublicAPI]
+        public async Task<Stream> ExecuteRequestAsync(IApiRequest request, 
+            CancellationToken cancelToken = default)
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
 

--- a/lib/GotenbergSharpClient.cs
+++ b/lib/GotenbergSharpClient.cs
@@ -195,7 +195,7 @@ namespace Gotenberg.Sharp.API.Client
         }
 
         /// <summary>
-        /// Send an api reuqest
+        /// Send an Api Request
         /// </summary>
         /// <param name="request"></param>
         /// <param name="option"></param>

--- a/lib/GotenbergSharpClient.cs
+++ b/lib/GotenbergSharpClient.cs
@@ -153,7 +153,7 @@ namespace Gotenberg.Sharp.API.Client
                 throw new InvalidOperationException(
                     "Only call this for webhook configured requests");
 
-            using var response = await SendRequest(
+            using var response = await SendRequestAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
                 cancelToken);
@@ -164,7 +164,7 @@ namespace Gotenberg.Sharp.API.Client
         #region exec
 
         /// <summary>
-        /// Support custom request type
+        /// Execute an Api Request
         /// </summary>
         /// <param name="request"></param>
         /// <param name="cancelToken"></param>
@@ -176,7 +176,7 @@ namespace Gotenberg.Sharp.API.Client
         {
             if (request == null) throw new ArgumentNullException(nameof(request));
 
-            using var response = await this.SendRequest(
+            using var response = await this.SendRequestAsync(
                 request,
                 HttpCompletionOption.ResponseHeadersRead,
                 cancelToken);
@@ -194,7 +194,15 @@ namespace Gotenberg.Sharp.API.Client
             return ms;
         }
 
-        async Task<HttpResponseMessage> SendRequest(
+        /// <summary>
+        /// Send an api reuqest
+        /// </summary>
+        /// <param name="request"></param>
+        /// <param name="option"></param>
+        /// <param name="cancelToken"></param>
+        /// <returns></returns>
+        [PublicAPI]
+        public async Task<HttpResponseMessage> SendRequestAsync(
             IApiRequest request,
             HttpCompletionOption option,
             CancellationToken cancelToken)

--- a/lib/GotenbergSharpClient.cs
+++ b/lib/GotenbergSharpClient.cs
@@ -43,7 +43,7 @@ namespace Gotenberg.Sharp.API.Client
     ///     https://github.com/gotenberg/awesome-gotenberg#clients
     /// </para>
     /// </remarks>
-    public sealed class GotenbergSharpClient
+    public class GotenbergSharpClient
     {
         readonly HttpClient _innerClient;
 


### PR DESCRIPTION
This PR is to allow customising the request type.

My company has added some custom endpoints/behaviour to the existing Gotenberg image, and we'd like to be able to use this client library to support existing AND new custom methods, however the methods are private.


