### PR TITLE
String repr of Dimension is system culture sensitive

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -76,3 +76,13 @@ dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
 end_of_line = crlf
+
+# Verify settings
+[*.{received,verified}.{json,txt,xml}]
+charset = "utf-8-bom"
+end_of_line = lf
+indent_size = unset
+indent_style = unset
+insert_final_newline = false
+tab_width = unset
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -288,3 +288,6 @@ __pycache__/
 *.odx.cs
 *.xsd.cs
 
+# Verify
+*.received.*
+*.received/

--- a/Gotenberg.Sharp.Api.Client.Tests/Domain/Builders/HtmlRequestBuilderTests.ToApiRequestMessage_PaperDimensionWithDecimal_NumbersUsesDotAsDecimalSeparator_Test.verified.txt
+++ b/Gotenberg.Sharp.Api.Client.Tests/Domain/Builders/HtmlRequestBuilderTests.ToApiRequestMessage_PaperDimensionWithDecimal_NumbersUsesDotAsDecimalSeparator_Test.verified.txt
@@ -1,0 +1,60 @@
+﻿Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=scale
+
+1
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=paperWidth
+
+8.5in
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=paperHeight
+
+12.2in
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=marginTop
+
+1in
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=marginBottom
+
+1in
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=marginLeft
+
+1in
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=marginRight
+
+1in
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=landscape
+
+False
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=preferCssPageSize
+
+False
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=printBackground
+
+False
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=omitBackground
+
+False
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=generateDocumentOutline
+
+False
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=failOnConsoleExceptions
+
+False
+Content-Type: text/plain; charset=utf-8
+Content-Disposition: form-data; name=skipNetworkIdleEvent
+
+False
+Content-Type: text/html
+Content-Disposition: form-data; name=files; filename=index.html
+
+<h1>Hello</h1>

--- a/Gotenberg.Sharp.Api.Client.Tests/Domain/Builders/HtmlRequestBuilderTests.cs
+++ b/Gotenberg.Sharp.Api.Client.Tests/Domain/Builders/HtmlRequestBuilderTests.cs
@@ -1,0 +1,38 @@
+// Copyright 2019-2025 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Gotenberg.Sharp.API.Client.Domain.Builders;
+
+namespace Gotenberg.Sharp.Api.Client.Tests.Domain.Builders;
+
+public sealed class HtmlRequestBuilderTests
+{
+    [Fact]
+    public Task ToApiRequestMessage_PaperDimensionWithDecimal_NumbersUsesDotAsDecimalSeparator_Test()
+    {
+        // Arrange.
+        var builder = new HtmlRequestBuilder()
+            .AddDocument(doc => doc.SetBody("<h1>Hello</h1>"))
+            .WithPageProperties(pp => pp.SetPaperHeight(12.2).SetPaperWidth(8.5));
+
+        // Act.
+        var request = builder.Build().CreateApiRequest().ToApiRequestMessage();
+
+        // Assert.
+        Assert.NotNull(request.Content);
+        return Verify(request.Content.ReadAsStringAsync())
+            .ScrubLines(x => x.StartsWith("----------------------------"));
+    }
+}

--- a/Gotenberg.Sharp.Api.Client.Tests/Domain/Dimensions/DimensionTests.cs
+++ b/Gotenberg.Sharp.Api.Client.Tests/Domain/Dimensions/DimensionTests.cs
@@ -1,0 +1,31 @@
+// Copyright 2019-2025 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Gotenberg.Sharp.API.Client.Domain.Dimensions;
+
+namespace Gotenberg.Sharp.Api.Client.Tests.Domain.Dimensions;
+
+public sealed class DimensionTests
+{
+    [Fact]
+    public void ToString_DecimalValue_UsesDotAsDecimalSeparator_Test()
+    {
+        // Arrange.
+        var dimension = new Dimension(11.7, DimensionUnitType.Inches);
+        
+        // Act and assert.
+        Assert.Equal("11.7in", dimension.ToString());
+    }
+}

--- a/Gotenberg.Sharp.Api.Client.Tests/Gotenberg.Sharp.Api.Client.Tests.csproj
+++ b/Gotenberg.Sharp.Api.Client.Tests/Gotenberg.Sharp.Api.Client.Tests.csproj
@@ -1,0 +1,32 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net9.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.4">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+        <PackageReference Include="Verify.Xunit" Version="28.11.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <ItemGroup>
+        <Using Include="Xunit"/>
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\lib\Gotenberg.Sharp.Api.Client.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/GotenbergSharpApiClient.sln
+++ b/GotenbergSharpApiClient.sln
@@ -10,6 +10,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.editorconfig = .editorconfig
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Gotenberg.Sharp.Api.Client.Tests", "Gotenberg.Sharp.Api.Client.Tests\Gotenberg.Sharp.Api.Client.Tests.csproj", "{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,18 @@ Global
 		{75F783A4-9392-412F-9DFE-00EE89527C10}.Release|x64.Build.0 = Release|Any CPU
 		{75F783A4-9392-412F-9DFE-00EE89527C10}.Release|x86.ActiveCfg = Release|Any CPU
 		{75F783A4-9392-412F-9DFE-00EE89527C10}.Release|x86.Build.0 = Release|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Debug|x64.Build.0 = Debug|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Debug|x86.Build.0 = Debug|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Release|x64.ActiveCfg = Release|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Release|x64.Build.0 = Release|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Release|x86.ActiveCfg = Release|Any CPU
+		{35A8F98F-E753-472B-8CEB-CF31BA9B0D9A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/lib/Domain/Dimensions/Dimension.cs
+++ b/lib/Domain/Dimensions/Dimension.cs
@@ -14,6 +14,7 @@
 //  limitations under the License.
 
 using System.ComponentModel;
+using System.Globalization;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
@@ -147,7 +148,7 @@ public sealed class Dimension(double value, DimensionUnitType unitType) : IEquat
 
     public override string ToString()
     {
-        return $"{Value}{UnitType.GetDescription()}";
+        return $"{Value.ToString(CultureInfo.InvariantCulture)}{UnitType.GetDescription()}";
     }
 
     public override bool Equals(object? obj)


### PR DESCRIPTION
Gotenberg do not support decimal numbers with comma decimal separator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal configuration to standardize file formatting and manage ignored content.

- **Refactor**
  - Improved numeric formatting for dimensions to ensure a consistent decimal display across all locales.

- **Tests**
  - Added automated tests to validate HTML request processing and accurate handling of paper dimensions.

These updates enhance overall consistency and reliability while ensuring uniform behavior in document processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->