### PR TITLE
Add singlePage page Property

### DIFF
--- a/lib/Domain/Builders/Faceted/PagePropertyBuilder.cs
+++ b/lib/Domain/Builders/Faceted/PagePropertyBuilder.cs
@@ -42,6 +42,12 @@ public sealed class PagePropertyBuilder(PageProperties pageProperties)
 
         return this;
     }
+    
+    public PagePropertyBuilder SetSinglePage(bool singlePage = true)
+    {
+        this._pageProperties.SinglePage = singlePage;
+        return this;
+    }
 
     public PagePropertyBuilder SetPaperSize(PaperSizes sizes)
     {

--- a/lib/Domain/Requests/Facets/PageProperties.cs
+++ b/lib/Domain/Requests/Facets/PageProperties.cs
@@ -137,6 +137,12 @@ namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets
         [MultiFormHeader(Constants.Gotenberg.Chromium.Shared.PageProperties.GenerateDocumentOutline)]
         public bool GenerateDocumentOutline { get; set; }
 
+        /// <summary>
+        /// Get or set a value indicating whether the PDF should be generated as a single page. (Will override the paper size)
+        /// </summary>
+        [MultiFormHeader(Constants.Gotenberg.Chromium.Shared.PageProperties.SinglePage)]
+        public bool SinglePage { get; set; }
+        
         #endregion
 
         #region public methods

--- a/lib/Infrastructure/Constants.cs
+++ b/lib/Infrastructure/Constants.cs
@@ -250,6 +250,8 @@ public static class Constants
                     public const string Scale = "scale";
 
                     public const string PageRanges = CrossCutting.PageRanges;
+                    
+                    public const string SinglePage = "singlePage";
                 }
 
                 public static class HtmlConvert


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for generating PDFs as a single page, overriding paper size settings. Users can now specify this option when configuring PDF generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fix #57 