### PR TITLE
Add strongly-typed cookie support for Gotenberg API

### DIFF
--- a/lib/Domain/Builders/Faceted/DocumentBuilder.cs
+++ b/lib/Domain/Builders/Faceted/DocumentBuilder.cs
@@ -26,9 +26,7 @@ public sealed class DocumentBuilder
 
     public DocumentBuilder(FullDocument content, Action<bool> setContainsMarkdown)
     {
-        if (content == null) throw new ArgumentNullException(nameof(content));
-
-        this._content = content;
+        this._content = content ?? throw new ArgumentNullException(nameof(content));
         this._setContainsMarkdown = setContainsMarkdown;
     }
 

--- a/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilder.cs
+++ b/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilder.cs
@@ -23,7 +23,7 @@ public sealed class HtmlConversionBehaviorBuilder
 
     internal HtmlConversionBehaviorBuilder(HtmlConversionBehaviors htmlConversionBehaviors)
     {
-        this._htmlConversionBehaviors = htmlConversionBehaviors;
+        _htmlConversionBehaviors = htmlConversionBehaviors;
     }
 
     /// <summary>
@@ -34,7 +34,7 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <remarks>Prefer <see cref="SetBrowserWaitExpression" /> over waitDelay.</remarks>
     public HtmlConversionBehaviorBuilder SetBrowserWaitDelay(int seconds)
     {
-        this._htmlConversionBehaviors.WaitDelay = $"{seconds}s";
+        _htmlConversionBehaviors.WaitDelay = $"{seconds}s";
 
         return this;
     }
@@ -49,9 +49,12 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <exception cref="InvalidOperationException"></exception>
     public HtmlConversionBehaviorBuilder SetBrowserWaitExpression(string expression)
     {
-        if (expression.IsNotSet()) throw new InvalidOperationException("expression is not set");
+        if (expression.IsNotSet())
+        {
+            throw new InvalidOperationException("expression is not set");
+        }
 
-        this._htmlConversionBehaviors.WaitForExpression = expression;
+        _htmlConversionBehaviors.WaitForExpression = expression;
 
         return this;
     }
@@ -65,9 +68,12 @@ public sealed class HtmlConversionBehaviorBuilder
     [Obsolete("Deprecated in Gotenberg v8+")]
     public HtmlConversionBehaviorBuilder SetUserAgent(string userAgent)
     {
-        if (userAgent.IsNotSet()) throw new InvalidOperationException("headerName is not set");
+        if (userAgent.IsNotSet())
+        {
+            throw new InvalidOperationException("headerName is not set");
+        }
 
-        this._htmlConversionBehaviors.UserAgent = userAgent;
+        _htmlConversionBehaviors.UserAgent = userAgent;
 
         return this;
     }
@@ -84,7 +90,7 @@ public sealed class HtmlConversionBehaviorBuilder
     {
         var header = string.Format("{0}{2}{1}", "{", "}", $"{'"'}{headerName}{'"'} : {'"'}{headerValue}{'"'}");
 
-        return this.AddAdditionalHeaders(JObject.Parse(header));
+        return AddAdditionalHeaders(JObject.Parse(header));
     }
 
     /// <summary>
@@ -95,85 +101,42 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <exception cref="InvalidOperationException"></exception>
     public HtmlConversionBehaviorBuilder AddAdditionalHeaders(JObject extraHeaders)
     {
-        if (extraHeaders == null) throw new InvalidOperationException("extraHeaders is null");
+        if (extraHeaders == null)
+        {
+            throw new InvalidOperationException("extraHeaders is null");
+        }
 
-        this._htmlConversionBehaviors.ExtraHeaders = extraHeaders;
+        _htmlConversionBehaviors.ExtraHeaders = extraHeaders;
 
         return this;
     }
 
     /// <summary>
-    /// Adds a cookie to store in the Chromium cookie jar.
+    ///     Adds a cookie to store in the Chromium cookie jar.
     /// </summary>
     /// <param name="cookie">The cookie to add</param>
     /// <returns></returns>
     /// <exception cref="ArgumentNullException"></exception>
     public HtmlConversionBehaviorBuilder AddCookie(Cookie cookie)
     {
-        if (cookie == null) throw new ArgumentNullException(nameof(cookie));
+        if (cookie == null)
+        {
+            throw new ArgumentNullException(nameof(cookie));
+        }
 
-        this._htmlConversionBehaviors.Cookies ??= new List<Cookie>();
+        _htmlConversionBehaviors.Cookies ??= new List<Cookie>();
 
         Cookie.Validate(cookie);
 
-        this._htmlConversionBehaviors.Cookies.Add(cookie);
+        _htmlConversionBehaviors.Cookies.Add(cookie);
 
         return this;
     }
 
     /// <summary>
-    /// Adds a cookie to store in the Chromium cookie jar.
-    /// </summary>
-    /// <param name="name">Cookie name</param>
-    /// <param name="value">Cookie value</param>
-    /// <param name="domain">Cookie domain</param>
-    /// <param name="path">Optional cookie path</param>
-    /// <param name="secure">Optional secure flag</param>
-    /// <param name="httpOnly">Optional HTTP-only flag</param>
-    /// <param name="sameSite">Optional SameSite attribute ("Strict", "Lax", or "None")</param>
-    /// <returns></returns>
-    public HtmlConversionBehaviorBuilder AddCookie(
-        string name,
-        string value,
-        string domain,
-        string? path = null,
-        bool? secure = null,
-        bool? httpOnly = null,
-        string? sameSite = null)
-    {
-        var cookie = new Cookie
-        {
-            Name = name,
-            Value = value,
-            Domain = domain,
-            Path = path,
-            Secure = secure,
-            HttpOnly = httpOnly,
-            SameSite = sameSite
-        };
-
-        return AddCookie(cookie);
-    }
-
-    /// <summary>
-    /// Adds multiple cookies to store in the Chromium cookie jar.
-    /// </summary>
-    /// <param name="cookies">The cookies to add</param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentNullException"></exception>
-    public HtmlConversionBehaviorBuilder AddCookies(IEnumerable<Cookie> cookies)
-    {
-        if (cookies == null) throw new ArgumentNullException(nameof(cookies));
-
-        this._htmlConversionBehaviors.Cookies ??= new List<Cookie>();
-        this._htmlConversionBehaviors.Cookies.AddRange(cookies);
-
-        return this;
-    }
-
-    /// <summary>
-    /// Sets the document metadata.
-    /// Not all metadata are writable. Consider taking a look at https://exiftool.org/TagNames/XMP.html#pdf for an (exhaustive?) list of available metadata.
+    ///     Sets the document metadata.
+    ///     Not all metadata are writable. Consider taking a look at https://exiftool.org/TagNames/XMP.html#pdf for an
+    ///     (exhaustive?) list of available metadata.
     /// </summary>
     /// <param name="dictionary"></param>
     /// <returns></returns>
@@ -185,16 +148,20 @@ public sealed class HtmlConversionBehaviorBuilder
     }
 
     /// <summary>
-    /// Sets the document metadata.
-    /// Not all metadata are writable. Consider taking a look at https://exiftool.org/TagNames/XMP.html#pdf for an (exhaustive?) list of available metadata.
+    ///     Sets the document metadata.
+    ///     Not all metadata are writable. Consider taking a look at https://exiftool.org/TagNames/XMP.html#pdf for an
+    ///     (exhaustive?) list of available metadata.
     /// </summary>
     /// <param name="metadata"></param>
     /// <returns></returns>
     public HtmlConversionBehaviorBuilder SetMetadata(JObject metadata)
     {
-        if (metadata == null) throw new InvalidOperationException("metadata is null");
+        if (metadata == null)
+        {
+            throw new InvalidOperationException("metadata is null");
+        }
 
-        this._htmlConversionBehaviors.MetaData = metadata;
+        _htmlConversionBehaviors.MetaData = metadata;
 
         return this;
     }
@@ -205,7 +172,7 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <returns></returns>
     public HtmlConversionBehaviorBuilder FailOnConsoleExceptions()
     {
-        this._htmlConversionBehaviors.FailOnConsoleExceptions = true;
+        _htmlConversionBehaviors.FailOnConsoleExceptions = true;
 
         return this;
     }
@@ -216,18 +183,18 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <returns></returns>
     public HtmlConversionBehaviorBuilder EmulateAsScreen()
     {
-        this._htmlConversionBehaviors.EmulatedMediaType = "screen";
+        _htmlConversionBehaviors.EmulatedMediaType = "screen";
 
         return this;
     }
 
     /// <summary>
-    ///     Gotenberg 8+ ONLY: Configures gotenberg to not wait for Chromium network to be idle. 
+    ///     Gotenberg 8+ ONLY: Configures gotenberg to not wait for Chromium network to be idle.
     /// </summary>
     /// <returns></returns>
     public HtmlConversionBehaviorBuilder SkipNetworkIdleEvent()
     {
-        this._htmlConversionBehaviors.SkipNetworkIdleEvent = true;
+        _htmlConversionBehaviors.SkipNetworkIdleEvent = true;
 
         return this;
     }
@@ -240,9 +207,12 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <exception cref="InvalidOperationException"></exception>
     public HtmlConversionBehaviorBuilder SetPdfFormat(ConversionPdfFormats format)
     {
-        if (format == default) throw new InvalidOperationException("Invalid PDF format specified");
+        if (format == default)
+        {
+            throw new InvalidOperationException("Invalid PDF format specified");
+        }
 
-        this._htmlConversionBehaviors.PdfFormat = format;
+        _htmlConversionBehaviors.PdfFormat = format;
 
         return this;
     }
@@ -252,7 +222,7 @@ public sealed class HtmlConversionBehaviorBuilder
     /// </summary>
     public HtmlConversionBehaviorBuilder SetPdfUa(bool enablePdfUa = true)
     {
-        this._htmlConversionBehaviors.EnablePdfUa = enablePdfUa;
+        _htmlConversionBehaviors.EnablePdfUa = enablePdfUa;
 
         return this;
     }

--- a/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilder.cs
+++ b/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilder.cs
@@ -113,6 +113,9 @@ public sealed class HtmlConversionBehaviorBuilder
         if (cookie == null) throw new ArgumentNullException(nameof(cookie));
 
         this._htmlConversionBehaviors.Cookies ??= new List<Cookie>();
+
+        Cookie.Validate(cookie);
+
         this._htmlConversionBehaviors.Cookies.Add(cookie);
 
         return this;

--- a/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilder.cs
+++ b/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilder.cs
@@ -95,9 +95,75 @@ public sealed class HtmlConversionBehaviorBuilder
     /// <exception cref="InvalidOperationException"></exception>
     public HtmlConversionBehaviorBuilder AddAdditionalHeaders(JObject extraHeaders)
     {
-        if (extraHeaders == null) throw new InvalidOperationException("headerValue is null");
+        if (extraHeaders == null) throw new InvalidOperationException("extraHeaders is null");
 
         this._htmlConversionBehaviors.ExtraHeaders = extraHeaders;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a cookie to store in the Chromium cookie jar.
+    /// </summary>
+    /// <param name="cookie">The cookie to add</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public HtmlConversionBehaviorBuilder AddCookie(Cookie cookie)
+    {
+        if (cookie == null) throw new ArgumentNullException(nameof(cookie));
+
+        this._htmlConversionBehaviors.Cookies ??= new List<Cookie>();
+        this._htmlConversionBehaviors.Cookies.Add(cookie);
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds a cookie to store in the Chromium cookie jar.
+    /// </summary>
+    /// <param name="name">Cookie name</param>
+    /// <param name="value">Cookie value</param>
+    /// <param name="domain">Cookie domain</param>
+    /// <param name="path">Optional cookie path</param>
+    /// <param name="secure">Optional secure flag</param>
+    /// <param name="httpOnly">Optional HTTP-only flag</param>
+    /// <param name="sameSite">Optional SameSite attribute ("Strict", "Lax", or "None")</param>
+    /// <returns></returns>
+    public HtmlConversionBehaviorBuilder AddCookie(
+        string name,
+        string value,
+        string domain,
+        string? path = null,
+        bool? secure = null,
+        bool? httpOnly = null,
+        string? sameSite = null)
+    {
+        var cookie = new Cookie
+        {
+            Name = name,
+            Value = value,
+            Domain = domain,
+            Path = path,
+            Secure = secure,
+            HttpOnly = httpOnly,
+            SameSite = sameSite
+        };
+
+        return AddCookie(cookie);
+    }
+
+    /// <summary>
+    /// Adds multiple cookies to store in the Chromium cookie jar.
+    /// </summary>
+    /// <param name="cookies">The cookies to add</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public HtmlConversionBehaviorBuilder AddCookies(IEnumerable<Cookie> cookies)
+    {
+        if (cookies == null) throw new ArgumentNullException(nameof(cookies));
+
+        this._htmlConversionBehaviors.Cookies ??= new List<Cookie>();
+        this._htmlConversionBehaviors.Cookies.AddRange(cookies);
 
         return this;
     }

--- a/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilderExtensions.cs
+++ b/lib/Domain/Builders/Faceted/HtmlConversionBehaviorBuilderExtensions.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2019-2025 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+// 
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+// 
+//      http://www.apache.org/licenses/LICENSE-2.0
+// 
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+namespace Gotenberg.Sharp.API.Client.Domain.Builders.Faceted;
+
+public static class HtmlConversionBehaviorBuilderExtensions
+{
+    /// <summary>
+    ///     Adds a cookie to store in the Chromium cookie jar.
+    /// </summary>
+    /// <param name="builder">HtmlConversionBehaviorBuilder</param>
+    /// <param name="name">Cookie name</param>
+    /// <param name="value">Cookie value</param>
+    /// <param name="domain">Cookie domain</param>
+    /// <param name="path">Optional cookie path</param>
+    /// <param name="secure">Optional secure flag</param>
+    /// <param name="httpOnly">Optional HTTP-only flag</param>
+    /// <param name="sameSite">Optional SameSite attribute ("Strict", "Lax", or "None")</param>
+    /// <returns></returns>
+    public static HtmlConversionBehaviorBuilder AddCookie(this HtmlConversionBehaviorBuilder builder,
+        string name,
+        string value,
+        string domain,
+        string? path = null,
+        bool? secure = null,
+        bool? httpOnly = null,
+        string? sameSite = null)
+    {
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        var cookie = new Cookie
+        {
+            Name = name,
+            Value = value,
+            Domain = domain,
+            Path = path,
+            Secure = secure,
+            HttpOnly = httpOnly,
+            SameSite = sameSite
+        };
+
+        return builder.AddCookie(cookie);
+    }
+
+    /// <summary>
+    ///     Adds multiple cookies to store in the Chromium cookie jar.
+    /// </summary>
+    /// <param name="builder">HtmlConversionBehaviorBuilder</param>
+    /// <param name="cookies">The cookies to add</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static HtmlConversionBehaviorBuilder AddCookies(this HtmlConversionBehaviorBuilder builder, IEnumerable<Cookie> cookies)
+    {
+        if (builder == null)
+        {
+            throw new ArgumentNullException(nameof(builder));
+        }
+
+        if (cookies == null)
+        {
+            throw new ArgumentNullException(nameof(cookies));
+        }
+
+        foreach (var c in cookies)
+        {
+            builder.AddCookie(c);
+        }
+
+        return builder;
+    }
+}

--- a/lib/Domain/Requests/Facets/Cookie.cs
+++ b/lib/Domain/Requests/Facets/Cookie.cs
@@ -1,0 +1,67 @@
+// Copyright 2019-2025 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Newtonsoft.Json;
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
+
+/// <summary>
+/// Represents a cookie to store in the Chromium cookie jar.
+/// See https://gotenberg.dev/docs/routes#cookies-chromium for details.
+/// </summary>
+public sealed record Cookie
+{
+    /// <summary>
+    /// Cookie name (required)
+    /// </summary>
+    [JsonProperty("name")]
+    public required string Name { get; init; }
+
+    /// <summary>
+    /// Cookie value (required)
+    /// </summary>
+    [JsonProperty("value")]
+    public required string Value { get; init; }
+
+    /// <summary>
+    /// Cookie domain (required)
+    /// </summary>
+    [JsonProperty("domain")]
+    public required string Domain { get; init; }
+
+    /// <summary>
+    /// Cookie path (optional)
+    /// </summary>
+    [JsonProperty("path", NullValueHandling = NullValueHandling.Ignore)]
+    public string? Path { get; init; }
+
+    /// <summary>
+    /// Set cookie as secure (optional)
+    /// </summary>
+    [JsonProperty("secure", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? Secure { get; init; }
+
+    /// <summary>
+    /// Set cookie as HTTP-only (optional)
+    /// </summary>
+    [JsonProperty("httpOnly", NullValueHandling = NullValueHandling.Ignore)]
+    public bool? HttpOnly { get; init; }
+
+    /// <summary>
+    /// SameSite attribute. Accepted values: "Strict", "Lax", or "None" (optional)
+    /// </summary>
+    [JsonProperty("sameSite", NullValueHandling = NullValueHandling.Ignore)]
+    public string? SameSite { get; init; }
+}

--- a/lib/Domain/Requests/Facets/Cookie.cs
+++ b/lib/Domain/Requests/Facets/Cookie.cs
@@ -64,4 +64,11 @@ public sealed record Cookie
     /// </summary>
     [JsonProperty("sameSite", NullValueHandling = NullValueHandling.Ignore)]
     public string? SameSite { get; init; }
+
+    public static void Validate(Cookie cookie)
+    {
+        if (cookie.Name.IsNotSet()) throw new ArgumentException("Cookie.Name must not be null or empty", nameof(cookie.Name));
+        if (cookie.Value.IsNotSet()) throw new ArgumentException("Cookie.Value must not be null or empty", nameof(cookie.Value));
+        if (cookie.Domain.IsNotSet()) throw new ArgumentException("Cookie.Domain must not be null or empty", nameof(cookie.Domain));
+    }
 }

--- a/lib/Domain/Requests/Facets/FacetBase.cs
+++ b/lib/Domain/Requests/Facets/FacetBase.cs
@@ -15,73 +15,75 @@
 
 using System.Globalization;
 
-namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets
+namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
+
+public abstract class FacetBase : IConvertToHttpContent
 {
-    public abstract class FacetBase : IConvertToHttpContent
+    public virtual IEnumerable<HttpContent> ToHttpContent()
     {
-        public virtual IEnumerable<HttpContent> ToHttpContent()
+        return MultiFormPropertyItem.FromType(GetType())
+            .Select(GetHttpContentFromProperty)
+            .WhereNotNull();
+    }
+
+    internal virtual HttpContent? GetHttpContentFromProperty(MultiFormPropertyItem item)
+    {
+        var value = item.Property.GetValue(this);
+
+        if (value == null)
         {
-            return MultiFormPropertyItem.FromType(this.GetType())
-                .Select(this.GetHttpContentFromProperty)
-                .WhereNotNull();
+            return null;
         }
 
-        internal virtual HttpContent? GetHttpContentFromProperty(MultiFormPropertyItem item)
+        HttpContent? httpContent;
+
+        if (value is ContentItem contentItem)
         {
-            var value = item.Property.GetValue(this);
+            httpContent = contentItem.ToHttpContentItem();
+        }
+        else
+        {
+            var convertedValue = GetValueAsInvariantCultureString(value);
 
-            if (value == null) return null;
-
-            HttpContent? httpContent;
-
-            if (value is ContentItem contentItem)
+            if (convertedValue == null)
             {
-                httpContent = contentItem.ToHttpContentItem();
-            }
-            else
-            {
-                var convertedValue = GetValueAsInvariantCultureString(value);
-
-                if (convertedValue == null)
-                {
-                    return null;
-                }
-
-                httpContent = new StringContent(convertedValue);
+                return null;
             }
 
-            httpContent.Headers.ContentType = new MediaTypeHeaderValue(item.Attribute.MediaType);
-            httpContent.Headers.ContentDisposition =
-                new ContentDispositionHeaderValue(item.Attribute.ContentDisposition)
-                {
-                    Name = item.Attribute.Name, FileName = item.Attribute.FileName
-                };
-
-            return httpContent;
+            httpContent = new StringContent(convertedValue);
         }
 
-        protected static string? GetValueAsInvariantCultureString(object? value)
-        {
-            if (value == null) return null;
-
-            var cultureInfo = CultureInfo.InvariantCulture;
-
-            return value switch
+        httpContent.Headers.ContentType = new MediaTypeHeaderValue(item.Attribute.MediaType);
+        httpContent.Headers.ContentDisposition =
+            new ContentDispositionHeaderValue(item.Attribute.ContentDisposition)
             {
-                LibrePdfFormats format => format.ToFormDataValue(),
-                ConversionPdfFormats format => format.ToFormDataValue(),
-using System.Globalization;
-using Newtonsoft.Json;
-
-namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets
-                float f => f.ToString(cultureInfo),
-                double d => d.ToString(cultureInfo),
-                decimal c => c.ToString(cultureInfo),
-                int i => i.ToString(cultureInfo),
-                long l => l.ToString(cultureInfo),
-                DateTime date => date.ToString(cultureInfo),
-                _ => value.ToString()
+                Name = item.Attribute.Name, FileName = item.Attribute.FileName
             };
+
+        return httpContent;
+    }
+
+    protected static string? GetValueAsInvariantCultureString(object? value)
+    {
+        if (value == null)
+        {
+            return null;
         }
+
+        var cultureInfo = CultureInfo.InvariantCulture;
+
+        return value switch
+        {
+            LibrePdfFormats format => format.ToFormDataValue(),
+            ConversionPdfFormats format => format.ToFormDataValue(),
+            List<Cookie> cookies => JsonConvert.SerializeObject(cookies),
+            float f => f.ToString(cultureInfo),
+            double d => d.ToString(cultureInfo),
+            decimal c => c.ToString(cultureInfo),
+            int i => i.ToString(cultureInfo),
+            long l => l.ToString(cultureInfo),
+            DateTime date => date.ToString(cultureInfo),
+            _ => value.ToString()
+        };
     }
 }

--- a/lib/Domain/Requests/Facets/FacetBase.cs
+++ b/lib/Domain/Requests/Facets/FacetBase.cs
@@ -70,7 +70,10 @@ namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets
             {
                 LibrePdfFormats format => format.ToFormDataValue(),
                 ConversionPdfFormats format => format.ToFormDataValue(),
-                List<Cookie> cookies => JsonConvert.SerializeObject(cookies),
+using System.Globalization;
+using Newtonsoft.Json;
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets
                 float f => f.ToString(cultureInfo),
                 double d => d.ToString(cultureInfo),
                 decimal c => c.ToString(cultureInfo),

--- a/lib/Domain/Requests/Facets/FacetBase.cs
+++ b/lib/Domain/Requests/Facets/FacetBase.cs
@@ -70,6 +70,7 @@ namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets
             {
                 LibrePdfFormats format => format.ToFormDataValue(),
                 ConversionPdfFormats format => format.ToFormDataValue(),
+                List<Cookie> cookies => JsonConvert.SerializeObject(cookies),
                 float f => f.ToString(cultureInfo),
                 double d => d.ToString(cultureInfo),
                 decimal c => c.ToString(cultureInfo),

--- a/lib/Domain/Requests/Facets/HtmlConversionBehaviors.cs
+++ b/lib/Domain/Requests/Facets/HtmlConversionBehaviors.cs
@@ -55,6 +55,12 @@ public class HtmlConversionBehaviors : FacetBase
     public JObject? ExtraHeaders { get; set; }
 
     /// <summary>
+    /// Cookies to store in the Chromium cookie jar.
+    /// </summary>
+    [MultiFormHeader(Constants.Gotenberg.Chromium.Shared.HtmlConvert.Cookies)]
+    public List<Cookie>? Cookies { get; set; }
+
+    /// <summary>
     /// The metadata to write to the PDF (JSON format).
     /// Not all metadata are writable.
     /// Consider taking a look at https://exiftool.org/TagNames/XMP.html#pdf for an (exhaustive?) list of available metadata.

--- a/lib/Gotenberg.Sharp.Api.Client.csproj
+++ b/lib/Gotenberg.Sharp.Api.Client.csproj
@@ -48,6 +48,10 @@
 	</PropertyGroup>
 
 	<ItemGroup>
+		<InternalsVisibleTo Include="GotenbergSharpClient.Tests" />
+	</ItemGroup>
+
+	<ItemGroup>
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 			<PrivateAssets>all</PrivateAssets>

--- a/lib/Infrastructure/Constants.cs
+++ b/lib/Infrastructure/Constants.cs
@@ -266,6 +266,8 @@ public static class Constants
 
                     public const string ExtraHttpHeaders = "extraHttpHeaders";
 
+                    public const string Cookies = "cookies";
+
                     public const string MetaData = "metadata";
 
                     //javascript

--- a/test/GotenbergSharpClient.Tests/CookieTests.cs
+++ b/test/GotenbergSharpClient.Tests/CookieTests.cs
@@ -1,0 +1,224 @@
+using Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace GotenbergSharpClient.Tests;
+
+[TestFixture]
+public class CookieTests
+{
+    [Test]
+    public void Cookie_WithRequiredFieldsOnly_SerializesToCorrectJson()
+    {
+        // Arrange
+        var cookie = new Cookie
+        {
+            Name = "yummy_cookie",
+            Value = "choco",
+            Domain = "theyummycookie.com"
+        };
+
+        // Act
+        var json = JsonConvert.SerializeObject(cookie);
+        var jObject = JObject.Parse(json);
+
+        // Assert
+        jObject["name"]!.Value<string>().Should().Be("yummy_cookie");
+        jObject["value"]!.Value<string>().Should().Be("choco");
+        jObject["domain"]!.Value<string>().Should().Be("theyummycookie.com");
+        jObject.ContainsKey("path").Should().BeFalse();
+        jObject.ContainsKey("secure").Should().BeFalse();
+        jObject.ContainsKey("httpOnly").Should().BeFalse();
+        jObject.ContainsKey("sameSite").Should().BeFalse();
+    }
+
+    [Test]
+    public void Cookie_WithAllFields_SerializesToCorrectJson()
+    {
+        // Arrange
+        var cookie = new Cookie
+        {
+            Name = "session_token",
+            Value = "abc123",
+            Domain = "example.com",
+            Path = "/api",
+            Secure = true,
+            HttpOnly = true,
+            SameSite = "Strict"
+        };
+
+        // Act
+        var json = JsonConvert.SerializeObject(cookie);
+        var jObject = JObject.Parse(json);
+
+        // Assert
+        jObject["name"]!.Value<string>().Should().Be("session_token");
+        jObject["value"]!.Value<string>().Should().Be("abc123");
+        jObject["domain"]!.Value<string>().Should().Be("example.com");
+        jObject["path"]!.Value<string>().Should().Be("/api");
+        jObject["secure"]!.Value<bool>().Should().BeTrue();
+        jObject["httpOnly"]!.Value<bool>().Should().BeTrue();
+        jObject["sameSite"]!.Value<string>().Should().Be("Strict");
+    }
+
+    [Test]
+    public void CookieList_SerializesToCorrectJsonArray()
+    {
+        // Arrange
+        var cookies = new List<Cookie>
+        {
+            new Cookie
+            {
+                Name = "yummy_cookie",
+                Value = "choco",
+                Domain = "theyummycookie.com"
+            },
+            new Cookie
+            {
+                Name = "session_token",
+                Value = "abc123",
+                Domain = "example.com",
+                Path = "/",
+                Secure = true,
+                HttpOnly = true,
+                SameSite = "Lax"
+            }
+        };
+
+        // Act
+        var json = JsonConvert.SerializeObject(cookies);
+        var jArray = JArray.Parse(json);
+
+        // Assert
+        jArray.Should().HaveCount(2);
+
+        var first = (JObject)jArray[0];
+        first["name"]!.Value<string>().Should().Be("yummy_cookie");
+        first["value"]!.Value<string>().Should().Be("choco");
+        first["domain"]!.Value<string>().Should().Be("theyummycookie.com");
+
+        var second = (JObject)jArray[1];
+        second["name"]!.Value<string>().Should().Be("session_token");
+        second["value"]!.Value<string>().Should().Be("abc123");
+        second["domain"]!.Value<string>().Should().Be("example.com");
+        second["path"]!.Value<string>().Should().Be("/");
+        second["secure"]!.Value<bool>().Should().BeTrue();
+        second["httpOnly"]!.Value<bool>().Should().BeTrue();
+        second["sameSite"]!.Value<string>().Should().Be("Lax");
+    }
+
+    [Test]
+    public void HtmlConversionBehaviors_WithCookies_ConvertsToCorrectHttpContent()
+    {
+        // Arrange
+        var behaviors = new HtmlConversionBehaviors
+        {
+            Cookies = new List<Cookie>
+            {
+                new Cookie
+                {
+                    Name = "test_cookie",
+                    Value = "test_value",
+                    Domain = "test.com"
+                }
+            }
+        };
+
+        // Act
+        var httpContents = behaviors.ToHttpContent().ToList();
+
+        // Assert
+        var cookieContent = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "cookies");
+
+        cookieContent.Should().NotBeNull("Cookie content should be present in HTTP content");
+
+        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var jArray = JArray.Parse(contentString);
+
+        jArray.Should().HaveCount(1);
+        var cookie = (JObject)jArray[0];
+        cookie["name"]!.Value<string>().Should().Be("test_cookie");
+        cookie["value"]!.Value<string>().Should().Be("test_value");
+        cookie["domain"]!.Value<string>().Should().Be("test.com");
+    }
+
+    [Test]
+    public void HtmlConversionBehaviors_WithMultipleCookies_ConvertsToCorrectJsonArray()
+    {
+        // Arrange
+        var behaviors = new HtmlConversionBehaviors
+        {
+            Cookies = new List<Cookie>
+            {
+                new Cookie { Name = "cookie1", Value = "value1", Domain = "domain1.com" },
+                new Cookie { Name = "cookie2", Value = "value2", Domain = "domain2.com", Secure = true },
+                new Cookie { Name = "cookie3", Value = "value3", Domain = "domain3.com", HttpOnly = true, SameSite = "None" }
+            }
+        };
+
+        // Act
+        var httpContents = behaviors.ToHttpContent().ToList();
+        var cookieContent = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "cookies");
+
+        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var jArray = JArray.Parse(contentString);
+
+        // Assert
+        jArray.Should().HaveCount(3);
+
+        var first = (JObject)jArray[0];
+        first["name"]!.Value<string>().Should().Be("cookie1");
+        first.ContainsKey("secure").Should().BeFalse();
+
+        var second = (JObject)jArray[1];
+        second["name"]!.Value<string>().Should().Be("cookie2");
+        second["secure"]!.Value<bool>().Should().BeTrue();
+
+        var third = (JObject)jArray[2];
+        third["name"]!.Value<string>().Should().Be("cookie3");
+        third["httpOnly"]!.Value<bool>().Should().BeTrue();
+        third["sameSite"]!.Value<string>().Should().Be("None");
+    }
+
+    [Test]
+    public void HtmlConversionBehaviors_WithNullCookies_DoesNotIncludeCookieContent()
+    {
+        // Arrange
+        var behaviors = new HtmlConversionBehaviors
+        {
+            Cookies = null
+        };
+
+        // Act
+        var httpContents = behaviors.ToHttpContent().ToList();
+
+        // Assert
+        var cookieContent = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "cookies");
+
+        cookieContent.Should().BeNull("Cookie content should not be present when Cookies is null");
+    }
+
+    [Test]
+    public void HtmlConversionBehaviors_WithEmptyCookieList_IncludesEmptyArray()
+    {
+        // Arrange
+        var behaviors = new HtmlConversionBehaviors
+        {
+            Cookies = new List<Cookie>()
+        };
+
+        // Act
+        var httpContents = behaviors.ToHttpContent().ToList();
+        var cookieContent = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "cookies");
+
+        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var jArray = JArray.Parse(contentString);
+
+        // Assert
+        jArray.Should().HaveCount(0, "Empty cookie list should serialize to empty JSON array");
+    }
+}

--- a/test/GotenbergSharpClient.Tests/HtmlConversionBehaviorBuilderTests.cs
+++ b/test/GotenbergSharpClient.Tests/HtmlConversionBehaviorBuilderTests.cs
@@ -128,6 +128,21 @@ public class HtmlConversionBehaviorBuilderTests
     }
 
     [Test]
+    public void AddCookie_CalledWithNullRequiredCookieValues_ThrowsException()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+
+        // Act
+        var act = () => builder.SetConversionBehaviors(b => b
+            .AddCookie("cookie1", null!, "domain1.com")
+            .AddCookie(null!, "value2", "domain2.com")
+            .AddCookie("cookie3", "value3", "domain3.com"));
+
+        act.Should().ThrowExactly<ArgumentException>("Caught cookie required field validation");
+    }
+
+    [Test]
     public void AddCookie_CalledMultipleTimes_AccumulatesCookies()
     {
         // Arrange

--- a/test/GotenbergSharpClient.Tests/HtmlConversionBehaviorBuilderTests.cs
+++ b/test/GotenbergSharpClient.Tests/HtmlConversionBehaviorBuilderTests.cs
@@ -1,6 +1,6 @@
 using Gotenberg.Sharp.API.Client.Domain.Builders;
+using Gotenberg.Sharp.API.Client.Domain.Builders.Faceted;
 using Gotenberg.Sharp.API.Client.Domain.Requests;
-using Gotenberg.Sharp.API.Client.Domain.Requests.ApiRequests;
 using Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
 using Newtonsoft.Json.Linq;
 
@@ -110,7 +110,7 @@ public class HtmlConversionBehaviorBuilderTests
 
         cookieContent.Should().NotBeNull("Cookie content should be present in HTTP request");
 
-        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var contentString = cookieContent.ReadAsStringAsync().Result;
         var jArray = JArray.Parse(contentString);
 
         jArray.Should().HaveCount(3);
@@ -186,7 +186,7 @@ public class HtmlConversionBehaviorBuilderTests
 
         // Assert
         cookieContent.Should().NotBeNull();
-        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var contentString = cookieContent.ReadAsStringAsync().Result;
         var jArray = JArray.Parse(contentString);
 
         jArray.Should().HaveCount(2);

--- a/test/GotenbergSharpClient.Tests/HtmlConversionBehaviorBuilderTests.cs
+++ b/test/GotenbergSharpClient.Tests/HtmlConversionBehaviorBuilderTests.cs
@@ -1,0 +1,193 @@
+using Gotenberg.Sharp.API.Client.Domain.Builders;
+using Gotenberg.Sharp.API.Client.Domain.Requests;
+using Gotenberg.Sharp.API.Client.Domain.Requests.ApiRequests;
+using Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
+using Newtonsoft.Json.Linq;
+
+namespace GotenbergSharpClient.Tests;
+
+[TestFixture]
+public class HtmlConversionBehaviorBuilderTests
+{
+    [Test]
+    public void AddCookie_WithCookieObject_AddsCookieToCollection()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+        var cookie = new Cookie
+        {
+            Name = "test",
+            Value = "value",
+            Domain = "example.com"
+        };
+
+        // Act
+        builder.SetConversionBehaviors(b => b.AddCookie(cookie));
+        var request = builder.Build();
+
+        // Assert
+        request.ConversionBehaviors.Cookies.Should().NotBeNull();
+        request.ConversionBehaviors.Cookies.Should().HaveCount(1);
+        request.ConversionBehaviors.Cookies![0].Should().Be(cookie);
+    }
+
+    [Test]
+    public void AddCookie_WithParameters_CreatesCookieCorrectly()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+
+        // Act
+        builder.SetConversionBehaviors(b => b.AddCookie(
+            name: "session",
+            value: "abc123",
+            domain: "example.com",
+            path: "/api",
+            secure: true,
+            httpOnly: true,
+            sameSite: "Strict"));
+
+        var request = builder.Build();
+
+        // Assert
+        request.ConversionBehaviors.Cookies.Should().NotBeNull();
+        request.ConversionBehaviors.Cookies.Should().HaveCount(1);
+        var cookie = request.ConversionBehaviors.Cookies![0];
+        cookie.Name.Should().Be("session");
+        cookie.Value.Should().Be("abc123");
+        cookie.Domain.Should().Be("example.com");
+        cookie.Path.Should().Be("/api");
+        cookie.Secure.Should().BeTrue();
+        cookie.HttpOnly.Should().BeTrue();
+        cookie.SameSite.Should().Be("Strict");
+    }
+
+    [Test]
+    public void AddCookie_WithMinimalParameters_CreatesBasicCookie()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+
+        // Act
+        builder.SetConversionBehaviors(b => b.AddCookie("name", "value", "domain.com"));
+        var request = builder.Build();
+
+        // Assert
+        request.ConversionBehaviors.Cookies.Should().NotBeNull();
+        request.ConversionBehaviors.Cookies.Should().HaveCount(1);
+        var cookie = request.ConversionBehaviors.Cookies![0];
+        cookie.Name.Should().Be("name");
+        cookie.Value.Should().Be("value");
+        cookie.Domain.Should().Be("domain.com");
+        cookie.Path.Should().BeNull();
+        cookie.Secure.Should().BeNull();
+        cookie.HttpOnly.Should().BeNull();
+        cookie.SameSite.Should().BeNull();
+    }
+
+    [Test]
+    public void AddCookies_WithEnumerable_AddsAllCookies()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+        var cookies = new[]
+        {
+            new Cookie { Name = "cookie1", Value = "value1", Domain = "domain1.com" },
+            new Cookie { Name = "cookie2", Value = "value2", Domain = "domain2.com" },
+            new Cookie { Name = "cookie3", Value = "value3", Domain = "domain3.com" }
+        };
+
+        // Act
+        builder
+            .AddDocument(doc => doc.SetBody("<html><body>Test</body></html>"))
+            .SetConversionBehaviors(b => b.AddCookies(cookies));
+        var apiRequest = (IConvertToHttpContent)builder.Build().CreateApiRequest();
+
+        // Assert - Test the internal HTTP content structure
+        var httpContents = apiRequest.ToHttpContent().ToList();
+        var cookieContent = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "cookies");
+
+        cookieContent.Should().NotBeNull("Cookie content should be present in HTTP request");
+
+        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var jArray = JArray.Parse(contentString);
+
+        jArray.Should().HaveCount(3);
+        jArray[0]["name"]!.Value<string>().Should().Be("cookie1");
+        jArray[0]["value"]!.Value<string>().Should().Be("value1");
+        jArray[0]["domain"]!.Value<string>().Should().Be("domain1.com");
+
+        jArray[1]["name"]!.Value<string>().Should().Be("cookie2");
+        jArray[1]["value"]!.Value<string>().Should().Be("value2");
+        jArray[1]["domain"]!.Value<string>().Should().Be("domain2.com");
+
+        jArray[2]["name"]!.Value<string>().Should().Be("cookie3");
+        jArray[2]["value"]!.Value<string>().Should().Be("value3");
+        jArray[2]["domain"]!.Value<string>().Should().Be("domain3.com");
+    }
+
+    [Test]
+    public void AddCookie_CalledMultipleTimes_AccumulatesCookies()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+
+        // Act
+        builder.SetConversionBehaviors(b => b
+            .AddCookie("cookie1", "value1", "domain1.com")
+            .AddCookie("cookie2", "value2", "domain2.com")
+            .AddCookie("cookie3", "value3", "domain3.com"));
+
+        var request = builder.Build();
+
+        // Assert
+        request.ConversionBehaviors.Cookies.Should().NotBeNull();
+        request.ConversionBehaviors.Cookies.Should().HaveCount(3);
+    }
+
+    [Test]
+    public void Builder_WithCookies_ProducesCorrectJsonInHttpContent()
+    {
+        // Arrange
+        var builder = new HtmlRequestBuilder();
+
+        // Act
+        builder.SetConversionBehaviors(b => b
+            .AddCookie("yummy_cookie", "choco", "theyummycookie.com")
+            .AddCookie(
+                name: "session",
+                value: "token123",
+                domain: "secure.com",
+                path: "/",
+                secure: true,
+                httpOnly: true,
+                sameSite: "Lax"));
+
+        var request = builder.Build();
+        var httpContents = request.ConversionBehaviors.ToHttpContent().ToList();
+        var cookieContent = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "cookies");
+
+        // Assert
+        cookieContent.Should().NotBeNull();
+        var contentString = cookieContent!.ReadAsStringAsync().Result;
+        var jArray = JArray.Parse(contentString);
+
+        jArray.Should().HaveCount(2);
+
+        var first = (JObject)jArray[0];
+        first["name"]!.Value<string>().Should().Be("yummy_cookie");
+        first["value"]!.Value<string>().Should().Be("choco");
+        first["domain"]!.Value<string>().Should().Be("theyummycookie.com");
+
+        var second = (JObject)jArray[1];
+        second["name"]!.Value<string>().Should().Be("session");
+        second["value"]!.Value<string>().Should().Be("token123");
+        second["domain"]!.Value<string>().Should().Be("secure.com");
+        second["path"]!.Value<string>().Should().Be("/");
+        second["secure"]!.Value<bool>().Should().BeTrue();
+        second["httpOnly"]!.Value<bool>().Should().BeTrue();
+        second["sameSite"]!.Value<string>().Should().Be("Lax");
+    }
+}


### PR DESCRIPTION
Implemented comprehensive cookie functionality replacing the poor JObject-based implementation:

- Created Cookie record with proper Gotenberg fields (name, value, domain, path, secure, httpOnly, sameSite)
- Updated HtmlConversionBehaviors to use List<Cookie> instead of JObject
- Added JSON serialization support in FacetBase for cookie collections
- Implemented fluent builder methods: AddCookie(Cookie), AddCookie(params), AddCookies(IEnumerable<Cookie>)
- Added InternalsVisibleTo attribute for test project
- Created comprehensive test suite (13 tests) validating JSON serialization and HTTP content generation

Resolves #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for sending cookies with HTML-to-PDF conversions (name, value, domain; optional path, secure, HttpOnly, SameSite) and builder APIs to add single or multiple cookies.
  * Added SetMetadata overload accepting IDictionary<string, object>.

* **Tests**
  * Added tests validating cookie serialization and inclusion in conversion requests (single, multiple, empty, null).

* **Documentation**
  * XML docs added for new cookie-related API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->