### PR TITLE
Add PDF encryption with userPassword and ownerPassword

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,23 @@ public async Task<Stream> ConvertToAccessiblePdfA(string pdfPath)
 }
 ```
 
+### PDF Encryption
+*Password-protect PDFs with user and owner passwords:*
+
+```csharp
+public async Task<Stream> CreateEncryptedPdf()
+{
+    var builder = new HtmlRequestBuilder()
+        .AddDocument(doc => doc.SetBody("<html><body><h1>Confidential</h1></body></html>"))
+        .SetPdfOutputOptions(o => o
+            .SetEncryption(userPassword: "reader123", ownerPassword: "admin456"))
+        .WithPageProperties(pp => pp.UseChromeDefaults());
+
+    var request = builder.Build();
+    return await _sharpClient.HtmlToPdfAsync(request);
+}
+```
+
 ### Flatten PDFs
 *Flatten PDF forms and annotations (v2.8+):*
 

--- a/examples/EncryptPdf/EncryptPdf.csproj
+++ b/examples/EncryptPdf/EncryptPdf.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/examples/EncryptPdf/Program.cs
+++ b/examples/EncryptPdf/Program.cs
@@ -18,12 +18,13 @@ Directory.CreateDirectory(destinationDirectory);
 
 var path = await CreateEncryptedPdf(destinationDirectory, options);
 Console.WriteLine($"Encrypted PDF created: {path}");
-Console.WriteLine("Open with password: reader123");
 
 static async Task<string> CreateEncryptedPdf(string destinationDirectory, GotenbergSharpClientOptions options)
 {
     var handler = new HttpClientHandler();
     HttpMessageHandler effectiveHandler = handler;
+    if (string.IsNullOrWhiteSpace(options.BasicAuthUsername) != string.IsNullOrWhiteSpace(options.BasicAuthPassword))
+        throw new InvalidOperationException("Both BasicAuthUsername and BasicAuthPassword must be provided, or neither.");
     if (!string.IsNullOrWhiteSpace(options.BasicAuthUsername) && !string.IsNullOrWhiteSpace(options.BasicAuthPassword))
         effectiveHandler = new BasicAuthHandler(options.BasicAuthUsername, options.BasicAuthPassword) { InnerHandler = handler };
 

--- a/examples/EncryptPdf/Program.cs
+++ b/examples/EncryptPdf/Program.cs
@@ -22,12 +22,12 @@ Console.WriteLine("Open with password: reader123");
 
 static async Task<string> CreateEncryptedPdf(string destinationDirectory, GotenbergSharpClientOptions options)
 {
-    using var handler = new HttpClientHandler();
-    using var authHandler = !string.IsNullOrWhiteSpace(options.BasicAuthUsername) && !string.IsNullOrWhiteSpace(options.BasicAuthPassword)
-        ? new BasicAuthHandler(options.BasicAuthUsername, options.BasicAuthPassword) { InnerHandler = handler }
-        : null;
+    var handler = new HttpClientHandler();
+    HttpMessageHandler effectiveHandler = handler;
+    if (!string.IsNullOrWhiteSpace(options.BasicAuthUsername) && !string.IsNullOrWhiteSpace(options.BasicAuthPassword))
+        effectiveHandler = new BasicAuthHandler(options.BasicAuthUsername, options.BasicAuthPassword) { InnerHandler = handler };
 
-    using var httpClient = new HttpClient(authHandler ?? (HttpMessageHandler)handler)
+    using var httpClient = new HttpClient(effectiveHandler, disposeHandler: true)
     {
         BaseAddress = options.ServiceUrl,
         Timeout = options.TimeOut

--- a/examples/EncryptPdf/Program.cs
+++ b/examples/EncryptPdf/Program.cs
@@ -1,0 +1,60 @@
+using Gotenberg.Sharp.API.Client;
+using Gotenberg.Sharp.API.Client.Domain.Builders;
+using Gotenberg.Sharp.API.Client.Domain.Settings;
+using Gotenberg.Sharp.API.Client.Infrastructure.Pipeline;
+
+using Microsoft.Extensions.Configuration;
+
+var config = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
+    .AddJsonFile("appsettings.json")
+    .Build();
+
+var options = new GotenbergSharpClientOptions();
+config.GetSection(nameof(GotenbergSharpClient)).Bind(options);
+
+var destinationDirectory = args.Length > 0 ? args[0] : Path.Combine(Directory.GetCurrentDirectory(), "output");
+Directory.CreateDirectory(destinationDirectory);
+
+var path = await CreateEncryptedPdf(destinationDirectory, options);
+Console.WriteLine($"Encrypted PDF created: {path}");
+Console.WriteLine("Open with password: reader123");
+
+static async Task<string> CreateEncryptedPdf(string destinationDirectory, GotenbergSharpClientOptions options)
+{
+    using var handler = new HttpClientHandler();
+    using var authHandler = !string.IsNullOrWhiteSpace(options.BasicAuthUsername) && !string.IsNullOrWhiteSpace(options.BasicAuthPassword)
+        ? new BasicAuthHandler(options.BasicAuthUsername, options.BasicAuthPassword) { InnerHandler = handler }
+        : null;
+
+    using var httpClient = new HttpClient(authHandler ?? (HttpMessageHandler)handler)
+    {
+        BaseAddress = options.ServiceUrl,
+        Timeout = options.TimeOut
+    };
+
+    var sharpClient = new GotenbergSharpClient(httpClient);
+
+    // Create a password-protected PDF
+    var builder = new HtmlRequestBuilder()
+        .AddDocument(doc => doc.SetBody(@"
+            <html><body>
+                <h1>Confidential Report</h1>
+                <p>This document is password protected.</p>
+            </body></html>"))
+        .SetPdfOutputOptions(o => o
+            .SetEncryption(
+                userPassword: "reader123",     // Required to open the PDF
+                ownerPassword: "admin456"))    // Required to change permissions
+        .WithPageProperties(pp => pp.UseChromeDefaults());
+
+    var request = builder.Build();
+    var response = await sharpClient.HtmlToPdfAsync(request);
+
+    var resultPath = Path.Combine(destinationDirectory, $"Encrypted-{DateTime.Now:yyyyMMddHHmmss}.pdf");
+
+    await using var destinationStream = File.Create(resultPath);
+    await response.CopyToAsync(destinationStream, CancellationToken.None);
+
+    return resultPath;
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Builders/Faceted/PdfOutputOptionsBuilder.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Builders/Faceted/PdfOutputOptionsBuilder.cs
@@ -13,6 +13,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
 using Newtonsoft.Json.Linq;
 
 namespace Gotenberg.Sharp.API.Client.Domain.Builders.Faceted;
@@ -109,6 +111,64 @@ public sealed class PdfOutputOptionsBuilder
         }
 
         _options.MetaData = metadata;
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the password required to open the resulting PDF.
+    /// </summary>
+    /// <param name="password">A validated PDF password.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public PdfOutputOptionsBuilder SetUserPassword(PdfPassword password)
+    {
+        _options.UserPassword = password ?? throw new ArgumentNullException(nameof(password));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the password required to open the resulting PDF.
+    /// </summary>
+    /// <param name="password">A non-empty password string.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public PdfOutputOptionsBuilder SetUserPassword(string password)
+    {
+        return SetUserPassword(PdfPassword.Create(password));
+    }
+
+    /// <summary>
+    /// Sets the password required to change permissions or edit the resulting PDF.
+    /// </summary>
+    /// <param name="password">A validated PDF password.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public PdfOutputOptionsBuilder SetOwnerPassword(PdfPassword password)
+    {
+        _options.OwnerPassword = password ?? throw new ArgumentNullException(nameof(password));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Sets the password required to change permissions or edit the resulting PDF.
+    /// </summary>
+    /// <param name="password">A non-empty password string.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public PdfOutputOptionsBuilder SetOwnerPassword(string password)
+    {
+        return SetOwnerPassword(PdfPassword.Create(password));
+    }
+
+    /// <summary>
+    /// Sets both user and owner passwords for the resulting PDF.
+    /// </summary>
+    /// <param name="userPassword">Password required to open the PDF.</param>
+    /// <param name="ownerPassword">Password required to change permissions.</param>
+    /// <returns>The builder instance for method chaining.</returns>
+    public PdfOutputOptionsBuilder SetEncryption(string userPassword, string ownerPassword)
+    {
+        SetUserPassword(userPassword);
+        SetOwnerPassword(ownerPassword);
 
         return this;
     }

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Builders/Faceted/PdfOutputOptionsBuilder.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Builders/Faceted/PdfOutputOptionsBuilder.cs
@@ -167,8 +167,12 @@ public sealed class PdfOutputOptionsBuilder
     /// <returns>The builder instance for method chaining.</returns>
     public PdfOutputOptionsBuilder SetEncryption(string userPassword, string ownerPassword)
     {
-        SetUserPassword(userPassword);
-        SetOwnerPassword(ownerPassword);
+        // Validate both passwords first before mutating any state
+        var validatedUser = PdfPassword.Create(userPassword);
+        var validatedOwner = PdfPassword.Create(ownerPassword);
+
+        _options.UserPassword = validatedUser;
+        _options.OwnerPassword = validatedOwner;
 
         return this;
     }

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/Facets/FacetBase.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/Facets/FacetBase.cs
@@ -15,6 +15,8 @@
 
 using System.Globalization;
 
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
 namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
 
 public abstract class FacetBase : IConvertToHttpContent
@@ -77,6 +79,7 @@ public abstract class FacetBase : IConvertToHttpContent
             PdfFormat format => format.ToFormDataValue(),
             LibrePdfFormats format => format.ToFormDataValue(),
             ConversionPdfFormats format => format.ToFormDataValue(),
+            PdfPassword password => password.Value,
             List<Cookie> cookies => JsonConvert.SerializeObject(cookies),
             float f => f.ToString(cultureInfo),
             double d => d.ToString(cultureInfo),

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/Facets/PdfOutputOptions.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/Facets/PdfOutputOptions.cs
@@ -13,6 +13,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
 using Newtonsoft.Json.Linq;
 
 namespace Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
@@ -54,4 +56,16 @@ public class PdfOutputOptions : FacetBase
     /// </summary>
     [MultiFormHeader(Constants.Gotenberg.PdfOutput.MetaData)]
     public JObject? MetaData { get; set; }
+
+    /// <summary>
+    /// The password required to open the PDF.
+    /// </summary>
+    [MultiFormHeader(Constants.Gotenberg.PdfOutput.UserPassword)]
+    public PdfPassword? UserPassword { get; set; }
+
+    /// <summary>
+    /// The password required to change permissions or edit the PDF.
+    /// </summary>
+    [MultiFormHeader(Constants.Gotenberg.PdfOutput.OwnerPassword)]
+    public PdfPassword? OwnerPassword { get; set; }
 }

--- a/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PdfPassword.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PdfPassword.cs
@@ -1,0 +1,57 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+namespace Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+/// <summary>
+/// Represents a validated PDF password used for encryption.
+/// Used for both userPassword (required to open) and ownerPassword (required to change permissions).
+/// </summary>
+public sealed class PdfPassword : IEquatable<PdfPassword>
+{
+    public string Value { get; }
+
+    private PdfPassword(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Creates a validated PDF password.
+    /// </summary>
+    /// <param name="password">A non-empty password string.</param>
+    /// <exception cref="ArgumentException">Thrown when the password is null or whitespace.</exception>
+    public static PdfPassword Create(string password)
+    {
+        if (string.IsNullOrWhiteSpace(password))
+            throw new ArgumentException("PDF password must not be null or empty.", nameof(password));
+
+        return new PdfPassword(password);
+    }
+
+    public override string ToString() => Value;
+
+    public bool Equals(PdfPassword? other) => other is not null && Value == other.Value;
+
+    public override bool Equals(object? obj) => Equals(obj as PdfPassword);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public static implicit operator string(PdfPassword password) => password.Value;
+
+    public static bool operator ==(PdfPassword? left, PdfPassword? right) => Equals(left, right);
+
+    public static bool operator !=(PdfPassword? left, PdfPassword? right) => !Equals(left, right);
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PdfPassword.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PdfPassword.cs
@@ -41,15 +41,13 @@ public sealed class PdfPassword : IEquatable<PdfPassword>
         return new PdfPassword(password);
     }
 
-    public override string ToString() => Value;
+    public override string ToString() => "****";
 
     public bool Equals(PdfPassword? other) => other is not null && Value == other.Value;
 
     public override bool Equals(object? obj) => Equals(obj as PdfPassword);
 
     public override int GetHashCode() => Value.GetHashCode();
-
-    public static implicit operator string(PdfPassword password) => password.Value;
 
     public static bool operator ==(PdfPassword? left, PdfPassword? right) => Equals(left, right);
 

--- a/src/Gotenberg.Sharp.Api.Client/Infrastructure/Constants.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Infrastructure/Constants.cs
@@ -88,6 +88,10 @@ public static class Constants
 
             internal const string MetaData = "metadata";
 
+            internal const string UserPassword = "userPassword";
+
+            internal const string OwnerPassword = "ownerPassword";
+
             internal static class FileNames
             {
                 internal const string Index = "index.html";
@@ -108,6 +112,10 @@ public static class Constants
             public const string GenerateTaggedPdf = CrossCutting.GenerateTaggedPdf;
 
             public const string MetaData = CrossCutting.MetaData;
+
+            public const string UserPassword = CrossCutting.UserPassword;
+
+            public const string OwnerPassword = CrossCutting.OwnerPassword;
         }
 
         /// <summary>

--- a/test/GotenbergSharpClient.Tests/EncryptionOptionsTests.cs
+++ b/test/GotenbergSharpClient.Tests/EncryptionOptionsTests.cs
@@ -4,6 +4,7 @@ using Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
 using Gotenberg.Sharp.API.Client.Domain.Settings;
 using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
 using Gotenberg.Sharp.API.Client.Extensions;
+using Gotenberg.Sharp.API.Client.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace GotenbergSharpClient.Tests;
@@ -19,7 +20,6 @@ public class EncryptionOptionsTests
         var password = PdfPassword.Create("secret123");
 
         password.Value.Should().Be("secret123");
-        password.ToString().Should().Be("secret123");
     }
 
     [TestCase(null)]
@@ -43,12 +43,11 @@ public class EncryptionOptionsTests
     }
 
     [Test]
-    public void PdfPassword_ImplicitConversion_ToStringReturnsValue()
+    public void PdfPassword_ToString_ReturnsRedactedValue()
     {
-        PdfPassword password = PdfPassword.Create("secret");
-        string result = password;
+        var password = PdfPassword.Create("secret");
 
-        result.Should().Be("secret");
+        password.ToString().Should().Be("****");
     }
 
     #endregion
@@ -115,7 +114,7 @@ public class EncryptionOptionsTests
 
         var httpContents = options.ToHttpContent().ToList();
         var content = httpContents.FirstOrDefault(c =>
-            c.Headers.ContentDisposition?.Name == "userPassword");
+            c.Headers.ContentDisposition?.Name == Constants.Gotenberg.PdfOutput.UserPassword);
 
         content.Should().NotBeNull();
         (await content!.ReadAsStringAsync()).Should().Be("openme");
@@ -131,7 +130,7 @@ public class EncryptionOptionsTests
 
         var httpContents = options.ToHttpContent().ToList();
         var content = httpContents.FirstOrDefault(c =>
-            c.Headers.ContentDisposition?.Name == "ownerPassword");
+            c.Headers.ContentDisposition?.Name == Constants.Gotenberg.PdfOutput.OwnerPassword);
 
         content.Should().NotBeNull();
         (await content!.ReadAsStringAsync()).Should().Be("editme");
@@ -145,9 +144,9 @@ public class EncryptionOptionsTests
         var httpContents = options.ToHttpContent().ToList();
 
         httpContents.FirstOrDefault(c =>
-            c.Headers.ContentDisposition?.Name == "userPassword").Should().BeNull();
+            c.Headers.ContentDisposition?.Name == Constants.Gotenberg.PdfOutput.UserPassword).Should().BeNull();
         httpContents.FirstOrDefault(c =>
-            c.Headers.ContentDisposition?.Name == "ownerPassword").Should().BeNull();
+            c.Headers.ContentDisposition?.Name == Constants.Gotenberg.PdfOutput.OwnerPassword).Should().BeNull();
     }
 
     #endregion

--- a/test/GotenbergSharpClient.Tests/EncryptionOptionsTests.cs
+++ b/test/GotenbergSharpClient.Tests/EncryptionOptionsTests.cs
@@ -1,0 +1,184 @@
+using Gotenberg.Sharp.API.Client.Domain.Builders;
+using Gotenberg.Sharp.API.Client.Domain.Builders.Faceted;
+using Gotenberg.Sharp.API.Client.Domain.Requests.Facets;
+using Gotenberg.Sharp.API.Client.Domain.Settings;
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+using Gotenberg.Sharp.API.Client.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace GotenbergSharpClient.Tests;
+
+[TestFixture]
+public class EncryptionOptionsTests
+{
+    #region PdfPassword Value Object Tests
+
+    [Test]
+    public void PdfPassword_Create_WithValidPassword_ReturnsInstance()
+    {
+        var password = PdfPassword.Create("secret123");
+
+        password.Value.Should().Be("secret123");
+        password.ToString().Should().Be("secret123");
+    }
+
+    [TestCase(null)]
+    [TestCase("")]
+    [TestCase("   ")]
+    public void PdfPassword_Create_WithNullOrEmpty_ThrowsArgumentException(string? input)
+    {
+        var act = () => PdfPassword.Create(input!);
+
+        act.Should().ThrowExactly<ArgumentException>();
+    }
+
+    [Test]
+    public void PdfPassword_Equality_WithSameValue_ReturnsTrue()
+    {
+        var a = PdfPassword.Create("secret");
+        var b = PdfPassword.Create("secret");
+
+        (a == b).Should().BeTrue();
+        a.Equals(b).Should().BeTrue();
+    }
+
+    [Test]
+    public void PdfPassword_ImplicitConversion_ToStringReturnsValue()
+    {
+        PdfPassword password = PdfPassword.Create("secret");
+        string result = password;
+
+        result.Should().Be("secret");
+    }
+
+    #endregion
+
+    #region Builder Tests
+
+    [Test]
+    public void SetUserPassword_WithString_SetsProperty()
+    {
+        var builder = new HtmlRequestBuilder();
+
+        builder.SetPdfOutputOptions(o => o.SetUserPassword("openme"));
+        var request = builder.Build();
+
+        request.PdfOutputOptions!.UserPassword.Should().NotBeNull();
+        request.PdfOutputOptions.UserPassword!.Value.Should().Be("openme");
+    }
+
+    [Test]
+    public void SetOwnerPassword_WithString_SetsProperty()
+    {
+        var builder = new HtmlRequestBuilder();
+
+        builder.SetPdfOutputOptions(o => o.SetOwnerPassword("editme"));
+        var request = builder.Build();
+
+        request.PdfOutputOptions!.OwnerPassword.Should().NotBeNull();
+        request.PdfOutputOptions.OwnerPassword!.Value.Should().Be("editme");
+    }
+
+    [Test]
+    public void SetEncryption_SetsBothPasswords()
+    {
+        var builder = new HtmlRequestBuilder();
+
+        builder.SetPdfOutputOptions(o => o.SetEncryption("user123", "owner456"));
+        var request = builder.Build();
+
+        request.PdfOutputOptions!.UserPassword!.Value.Should().Be("user123");
+        request.PdfOutputOptions.OwnerPassword!.Value.Should().Be("owner456");
+    }
+
+    [Test]
+    public void SetUserPassword_WithEmptyString_ThrowsArgumentException()
+    {
+        var builder = new HtmlRequestBuilder();
+
+        var act = () => builder.SetPdfOutputOptions(o => o.SetUserPassword(""));
+
+        act.Should().ThrowExactly<ArgumentException>();
+    }
+
+    #endregion
+
+    #region HTTP Content Serialization Tests
+
+    [Test]
+    public void UserPassword_SerializesToCorrectHttpContent()
+    {
+        var options = new PdfOutputOptions
+        {
+            UserPassword = PdfPassword.Create("openme")
+        };
+
+        var httpContents = options.ToHttpContent().ToList();
+        var content = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "userPassword");
+
+        content.Should().NotBeNull();
+        content!.ReadAsStringAsync().Result.Should().Be("openme");
+    }
+
+    [Test]
+    public void OwnerPassword_SerializesToCorrectHttpContent()
+    {
+        var options = new PdfOutputOptions
+        {
+            OwnerPassword = PdfPassword.Create("editme")
+        };
+
+        var httpContents = options.ToHttpContent().ToList();
+        var content = httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "ownerPassword");
+
+        content.Should().NotBeNull();
+        content!.ReadAsStringAsync().Result.Should().Be("editme");
+    }
+
+    [Test]
+    public void NullPasswords_NotIncludedInHttpContent()
+    {
+        var options = new PdfOutputOptions();
+
+        var httpContents = options.ToHttpContent().ToList();
+
+        httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "userPassword").Should().BeNull();
+        httpContents.FirstOrDefault(c =>
+            c.Headers.ContentDisposition?.Name == "ownerPassword").Should().BeNull();
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Test]
+    public async Task HtmlToPdf_WithEncryption_Succeeds()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<GotenbergSharpClientOptions>()
+            .Configure(options =>
+            {
+                options.ServiceUrl = new Uri("http://localhost:3000");
+                options.BasicAuthUsername = "testuser";
+                options.BasicAuthPassword = "testpass";
+            });
+        services.AddGotenbergSharpClient();
+        var client = services.BuildServiceProvider()
+            .GetRequiredService<Gotenberg.Sharp.API.Client.GotenbergSharpClient>();
+
+        var builder = new HtmlRequestBuilder()
+            .AddDocument(doc => doc.SetBody(
+                "<html><body><h1>Encrypted PDF</h1></body></html>"))
+            .SetPdfOutputOptions(o => o.SetEncryption("user123", "owner456"));
+
+        var result = await client.HtmlToPdfAsync(builder);
+
+        result.Should().NotBeNull();
+        result.Length.Should().BeGreaterThan(0);
+    }
+
+    #endregion
+}

--- a/test/GotenbergSharpClient.Tests/EncryptionOptionsTests.cs
+++ b/test/GotenbergSharpClient.Tests/EncryptionOptionsTests.cs
@@ -106,7 +106,7 @@ public class EncryptionOptionsTests
     #region HTTP Content Serialization Tests
 
     [Test]
-    public void UserPassword_SerializesToCorrectHttpContent()
+    public async Task UserPassword_SerializesToCorrectHttpContent()
     {
         var options = new PdfOutputOptions
         {
@@ -118,11 +118,11 @@ public class EncryptionOptionsTests
             c.Headers.ContentDisposition?.Name == "userPassword");
 
         content.Should().NotBeNull();
-        content!.ReadAsStringAsync().Result.Should().Be("openme");
+        (await content!.ReadAsStringAsync()).Should().Be("openme");
     }
 
     [Test]
-    public void OwnerPassword_SerializesToCorrectHttpContent()
+    public async Task OwnerPassword_SerializesToCorrectHttpContent()
     {
         var options = new PdfOutputOptions
         {
@@ -134,7 +134,7 @@ public class EncryptionOptionsTests
             c.Headers.ContentDisposition?.Name == "ownerPassword");
 
         content.Should().NotBeNull();
-        content!.ReadAsStringAsync().Result.Should().Be("editme");
+        (await content!.ReadAsStringAsync()).Should().Be("editme");
     }
 
     [Test]
@@ -154,6 +154,7 @@ public class EncryptionOptionsTests
 
     #region Integration Tests
 
+    [Category("Integration")]
     [Test]
     public async Task HtmlToPdf_WithEncryption_Succeeds()
     {


### PR DESCRIPTION
## Summary
- Add `userPassword` and `ownerPassword` fields to `PdfOutputOptions` (cross-cutting, available on all request types)
- Introduce `PdfPassword` DDD value object to validate non-empty password strings
- Expose `SetUserPassword`, `SetOwnerPassword`, and `SetEncryption` convenience methods on `PdfOutputOptionsBuilder`

## Test plan
- [x] 14 unit tests covering value object validation, builder API, and HTTP content serialization
- [x] 1 integration test verified against local Gotenberg 8
- [x] EncryptPdf example console app added
- [x] README section added

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PDF encryption support, enabling password-protected PDF generation with separate user and owner passwords for access control.

* **Documentation**
  * Added README section demonstrating PDF encryption configuration and usage.

* **Tests**
  * Added comprehensive encryption test suite validating password behavior and end-to-end PDF encryption workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->