### PR TITLE
Add standalone PDF engine operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,6 +492,34 @@ public async Task<Stream> FastConversion()
 }
 ```
 
+### Standalone PDF Engine Operations
+*Flatten, rotate, encrypt, and manipulate existing PDFs:*
+
+```csharp
+// Flatten form fields
+var flattenResult = await _sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.Flatten().WithPdfs(a => a.AddItem("form.pdf", pdfBytes)));
+
+// Rotate pages 90 degrees
+var rotateResult = await _sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.Rotate(90, "1-3").WithPdfs(a => a.AddItem("doc.pdf", pdfBytes)));
+
+// Encrypt with passwords
+var encrypted = await _sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.Encrypt("reader123", "admin456").WithPdfs(a => a.AddItem("doc.pdf", pdfBytes)));
+
+// Read metadata (returns JSON)
+var metadataJson = await _sharpClient.ReadPdfMetadataAsync(
+    PdfEngineBuilders.ReadMetadata().WithPdfs(a => a.AddItem("doc.pdf", pdfBytes)));
+
+// Write metadata
+var result = await _sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.WriteMetadata(new Dictionary<string, object>
+    {
+        { "Author", "John Doe" }, { "Title", "My Document" }
+    }).WithPdfs(a => a.AddItem("doc.pdf", pdfBytes)));
+```
+
 ### Custom Page Properties
 *Fine-tune page dimensions and properties:*
 

--- a/examples/PdfEngineOperations/PdfEngineOperations.csproj
+++ b/examples/PdfEngineOperations/PdfEngineOperations.csproj
@@ -1,0 +1,2 @@
+<Project Sdk="Microsoft.NET.Sdk">
+</Project>

--- a/examples/PdfEngineOperations/Program.cs
+++ b/examples/PdfEngineOperations/Program.cs
@@ -1,0 +1,103 @@
+using Gotenberg.Sharp.API.Client;
+using Gotenberg.Sharp.API.Client.Domain.Builders;
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+using Gotenberg.Sharp.API.Client.Domain.Settings;
+using Gotenberg.Sharp.API.Client.Infrastructure.Pipeline;
+
+using Microsoft.Extensions.Configuration;
+using Newtonsoft.Json.Linq;
+
+var config = new ConfigurationBuilder()
+    .SetBasePath(AppContext.BaseDirectory)
+    .AddJsonFile("appsettings.json")
+    .Build();
+
+var options = new GotenbergSharpClientOptions();
+config.GetSection(nameof(GotenbergSharpClient)).Bind(options);
+
+var destinationDirectory = args.Length > 0 ? args[0] : Path.Combine(Directory.GetCurrentDirectory(), "output");
+Directory.CreateDirectory(destinationDirectory);
+
+var sharpClient = CreateClient(options);
+
+// First generate a test PDF
+Console.WriteLine("Generating test PDF...");
+var pdfBytes = await GenerateTestPdf(sharpClient);
+
+// Flatten
+Console.WriteLine("Flattening PDF...");
+var flattenResult = await sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.Flatten().WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
+await SaveStream(flattenResult, destinationDirectory, "Flattened.pdf");
+
+// Rotate 90 degrees
+Console.WriteLine("Rotating PDF 90 degrees...");
+var rotateResult = await sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.Rotate(90).WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
+await SaveStream(rotateResult, destinationDirectory, "Rotated.pdf");
+
+// Encrypt
+Console.WriteLine("Encrypting PDF...");
+var encryptResult = await sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.Encrypt("reader123", "admin456").WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
+await SaveStream(encryptResult, destinationDirectory, "Encrypted.pdf");
+
+// Write metadata
+Console.WriteLine("Writing metadata...");
+var writeResult = await sharpClient.ExecutePdfEngineAsync(
+    PdfEngineBuilders.WriteMetadata(new Dictionary<string, object>
+    {
+        { "Author", "GotenbergSharpApiClient" },
+        { "Title", "PDF Engine Demo" }
+    }).WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
+await SaveStream(writeResult, destinationDirectory, "WithMetadata.pdf");
+
+// Read metadata
+Console.WriteLine("Reading metadata...");
+var metadataJson = await sharpClient.ReadPdfMetadataAsync(
+    PdfEngineBuilders.ReadMetadata().WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
+var parsed = JObject.Parse(metadataJson);
+Console.WriteLine($"Metadata: {parsed.ToString(Newtonsoft.Json.Formatting.Indented)}");
+
+Console.WriteLine($"\nAll output saved to: {destinationDirectory}");
+
+static async Task<byte[]> GenerateTestPdf(GotenbergSharpClient client)
+{
+    var builder = new HtmlRequestBuilder()
+        .AddDocument(doc => doc.SetBody(@"
+            <html><body>
+                <h1>PDF Engine Operations Demo</h1>
+                <p>This PDF is used to demonstrate standalone PDF engine operations.</p>
+                <form><input type='text' name='field1' value='Form field (will be flattened)'/></form>
+            </body></html>"));
+
+    var stream = await client.HtmlToPdfAsync(builder);
+    using var ms = new MemoryStream();
+    await stream.CopyToAsync(ms);
+    return ms.ToArray();
+}
+
+static async Task SaveStream(Stream stream, string directory, string filename)
+{
+    var path = Path.Combine(directory, $"{Path.GetFileNameWithoutExtension(filename)}-{DateTime.Now:yyyyMMddHHmmss}{Path.GetExtension(filename)}");
+    await using var file = File.Create(path);
+    await stream.CopyToAsync(file);
+    Console.WriteLine($"  Saved: {path}");
+}
+
+static GotenbergSharpClient CreateClient(GotenbergSharpClientOptions options)
+{
+    var handler = new HttpClientHandler();
+    HttpMessageHandler effectiveHandler = handler;
+
+    if (!string.IsNullOrWhiteSpace(options.BasicAuthUsername) && !string.IsNullOrWhiteSpace(options.BasicAuthPassword))
+        effectiveHandler = new BasicAuthHandler(options.BasicAuthUsername, options.BasicAuthPassword) { InnerHandler = handler };
+
+    var httpClient = new HttpClient(effectiveHandler)
+    {
+        BaseAddress = options.ServiceUrl,
+        Timeout = options.TimeOut
+    };
+
+    return new GotenbergSharpClient(httpClient);
+}

--- a/examples/PdfEngineOperations/Program.cs
+++ b/examples/PdfEngineOperations/Program.cs
@@ -26,25 +26,25 @@ var pdfBytes = await GenerateTestPdf(sharpClient);
 
 // Flatten
 Console.WriteLine("Flattening PDF...");
-var flattenResult = await sharpClient.ExecutePdfEngineAsync(
+using var flattenResult = await sharpClient.ExecutePdfEngineAsync(
     PdfEngineBuilders.Flatten().WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
 await SaveStream(flattenResult, destinationDirectory, "Flattened.pdf");
 
 // Rotate 90 degrees
 Console.WriteLine("Rotating PDF 90 degrees...");
-var rotateResult = await sharpClient.ExecutePdfEngineAsync(
+using var rotateResult = await sharpClient.ExecutePdfEngineAsync(
     PdfEngineBuilders.Rotate(90).WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
 await SaveStream(rotateResult, destinationDirectory, "Rotated.pdf");
 
 // Encrypt
 Console.WriteLine("Encrypting PDF...");
-var encryptResult = await sharpClient.ExecutePdfEngineAsync(
+using var encryptResult = await sharpClient.ExecutePdfEngineAsync(
     PdfEngineBuilders.Encrypt("reader123", "admin456").WithPdfs(a => a.AddItem("test.pdf", pdfBytes)));
 await SaveStream(encryptResult, destinationDirectory, "Encrypted.pdf");
 
 // Write metadata
 Console.WriteLine("Writing metadata...");
-var writeResult = await sharpClient.ExecutePdfEngineAsync(
+using var writeResult = await sharpClient.ExecutePdfEngineAsync(
     PdfEngineBuilders.WriteMetadata(new Dictionary<string, object>
     {
         { "Author", "GotenbergSharpApiClient" },
@@ -71,7 +71,7 @@ static async Task<byte[]> GenerateTestPdf(GotenbergSharpClient client)
                 <form><input type='text' name='field1' value='Form field (will be flattened)'/></form>
             </body></html>"));
 
-    var stream = await client.HtmlToPdfAsync(builder);
+    using var stream = await client.HtmlToPdfAsync(builder);
     using var ms = new MemoryStream();
     await stream.CopyToAsync(ms);
     return ms.ToArray();

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Builders/PdfEngineBuilder.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Builders/PdfEngineBuilder.cs
@@ -100,7 +100,7 @@ public static class PdfEngineBuilders
         var request = new SplitPdfRequest
         {
             Mode = mode,
-            Span = span ?? throw new ArgumentNullException(nameof(span)),
+            Span = !string.IsNullOrWhiteSpace(span) ? span : throw new ArgumentException("Span must not be null or whitespace.", nameof(span)),
             Unify = unify
         };
         return new PdfEngineBuilder<SplitPdfRequest>(request);

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Builders/PdfEngineBuilder.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Builders/PdfEngineBuilder.cs
@@ -1,0 +1,152 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+using Newtonsoft.Json.Linq;
+
+namespace Gotenberg.Sharp.API.Client.Domain.Builders;
+
+/// <summary>
+/// Builds standalone PDF engine requests. Use the static factory methods to create
+/// builders for specific operations (flatten, rotate, split, encrypt, metadata).
+/// </summary>
+public sealed class PdfEngineBuilder<TRequest>
+    : BaseBuilder<TRequest, PdfEngineBuilder<TRequest>>
+    where TRequest : PdfEngineRequest
+{
+    internal PdfEngineBuilder(TRequest request) : base(request)
+    {
+    }
+
+    /// <summary>
+    /// Adds PDF files to process.
+    /// </summary>
+    public PdfEngineBuilder<TRequest> WithPdfs(Action<AssetBuilder> action)
+    {
+        if (action == null) throw new ArgumentNullException(nameof(action));
+
+        action(new AssetBuilder(this.Request.Assets ??= new AssetDictionary()));
+
+        return this;
+    }
+
+    /// <summary>
+    /// Adds PDF files asynchronously.
+    /// </summary>
+    public PdfEngineBuilder<TRequest> WithPdfsAsync(Func<AssetBuilder, Task> asyncAction)
+    {
+        if (asyncAction == null) throw new ArgumentNullException(nameof(asyncAction));
+
+        this.BuildTasks.Add(asyncAction(new AssetBuilder(this.Request.Assets ??= new AssetDictionary())));
+
+        return this;
+    }
+}
+
+/// <summary>
+/// Static factory for creating PDF engine builders for specific operations.
+/// </summary>
+public static class PdfEngineBuilders
+{
+    /// <summary>
+    /// Creates a builder for flattening PDF form fields into static content.
+    /// </summary>
+    public static PdfEngineBuilder<FlattenPdfRequest> Flatten()
+    {
+        return new PdfEngineBuilder<FlattenPdfRequest>(new FlattenPdfRequest());
+    }
+
+    /// <summary>
+    /// Creates a builder for rotating PDF pages.
+    /// </summary>
+    public static PdfEngineBuilder<RotatePdfRequest> Rotate(RotationAngle angle, PageRanges? pages = null)
+    {
+        var request = new RotatePdfRequest
+        {
+            RotateAngle = angle ?? throw new ArgumentNullException(nameof(angle)),
+            RotatePages = pages
+        };
+        return new PdfEngineBuilder<RotatePdfRequest>(request);
+    }
+
+    /// <summary>
+    /// Creates a builder for rotating PDF pages.
+    /// </summary>
+    public static PdfEngineBuilder<RotatePdfRequest> Rotate(int angleDegrees, string? pages = null)
+    {
+        return Rotate(
+            RotationAngle.Create(angleDegrees),
+            pages != null ? PageRanges.Create(pages) : null);
+    }
+
+    /// <summary>
+    /// Creates a builder for splitting PDFs.
+    /// </summary>
+    public static PdfEngineBuilder<SplitPdfRequest> Split(SplitMode mode, string span, bool unify = false)
+    {
+        var request = new SplitPdfRequest
+        {
+            Mode = mode,
+            Span = span ?? throw new ArgumentNullException(nameof(span)),
+            Unify = unify
+        };
+        return new PdfEngineBuilder<SplitPdfRequest>(request);
+    }
+
+    /// <summary>
+    /// Creates a builder for encrypting PDFs with passwords.
+    /// </summary>
+    public static PdfEngineBuilder<EncryptPdfRequest> Encrypt(string userPassword, string? ownerPassword = null)
+    {
+        if (string.IsNullOrWhiteSpace(userPassword))
+            throw new ArgumentException("User password is required.", nameof(userPassword));
+
+        var request = new EncryptPdfRequest
+        {
+            UserPassword = userPassword,
+            OwnerPassword = ownerPassword
+        };
+        return new PdfEngineBuilder<EncryptPdfRequest>(request);
+    }
+
+    /// <summary>
+    /// Creates a builder for reading metadata from PDFs. Returns JSON.
+    /// </summary>
+    public static PdfEngineBuilder<ReadMetadataRequest> ReadMetadata()
+    {
+        return new PdfEngineBuilder<ReadMetadataRequest>(new ReadMetadataRequest());
+    }
+
+    /// <summary>
+    /// Creates a builder for writing metadata to PDFs.
+    /// </summary>
+    public static PdfEngineBuilder<WriteMetadataRequest> WriteMetadata(JObject metadata)
+    {
+        var request = new WriteMetadataRequest
+        {
+            Metadata = metadata ?? throw new ArgumentNullException(nameof(metadata))
+        };
+        return new PdfEngineBuilder<WriteMetadataRequest>(request);
+    }
+
+    /// <summary>
+    /// Creates a builder for writing metadata to PDFs.
+    /// </summary>
+    public static PdfEngineBuilder<WriteMetadataRequest> WriteMetadata(IDictionary<string, object> metadata)
+    {
+        return WriteMetadata(JObject.FromObject(metadata));
+    }
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/EncryptPdfRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/EncryptPdfRequest.cs
@@ -1,0 +1,34 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+public sealed class EncryptPdfRequest : PdfEngineRequest
+{
+    protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.Encrypt;
+
+    public string? UserPassword { get; set; }
+
+    public string? OwnerPassword { get; set; }
+
+    protected override void Validate()
+    {
+        if (string.IsNullOrWhiteSpace(this.UserPassword))
+            throw new InvalidOperationException("User password is required for encryption.");
+
+        base.Validate();
+    }
+
+    protected override IEnumerable<HttpContent> ToHttpContent()
+    {
+        yield return CreateFormDataItem(this.UserPassword!, "userPassword");
+
+        if (!string.IsNullOrWhiteSpace(this.OwnerPassword))
+            yield return CreateFormDataItem(this.OwnerPassword, "ownerPassword");
+
+        foreach (var content in base.ToHttpContent())
+            yield return content;
+    }
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/EncryptPdfRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/EncryptPdfRequest.cs
@@ -16,7 +16,7 @@ public sealed class EncryptPdfRequest : PdfEngineRequest
     protected override void Validate()
     {
         if (string.IsNullOrWhiteSpace(this.UserPassword))
-            throw new InvalidOperationException("User password is required for encryption.");
+            throw new ArgumentException("User password is required for encryption.");
 
         base.Validate();
     }

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/FlattenPdfRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/FlattenPdfRequest.cs
@@ -1,0 +1,11 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+public sealed class FlattenPdfRequest : PdfEngineRequest
+{
+    protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.Flatten;
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/FlattenPdfRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/FlattenPdfRequest.cs
@@ -5,6 +5,9 @@
 
 namespace Gotenberg.Sharp.API.Client.Domain.Requests;
 
+/// <summary>
+/// Flattens PDF form fields into static content.
+/// </summary>
 public sealed class FlattenPdfRequest : PdfEngineRequest
 {
     protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.Flatten;

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/PdfEngineRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/PdfEngineRequest.cs
@@ -1,0 +1,55 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+/// <summary>
+/// Base class for standalone PDF engine operations (flatten, rotate, split, encrypt,
+/// watermark, stamp, metadata). Each takes PDF files as input and returns processed output.
+/// </summary>
+public abstract class PdfEngineRequest : BuildRequestBase
+{
+    protected override void Validate()
+    {
+        if (this.Assets == null || !this.Assets.Any())
+            throw new InvalidOperationException("At least one PDF file is required.");
+
+        base.Validate();
+    }
+
+    protected override IEnumerable<HttpContent> ToHttpContent()
+    {
+        foreach (var item in this.Assets.IfNullEmpty().Where(item => item.IsValid()))
+        {
+            var contentItem = item.Value.ToHttpContentItem();
+
+            contentItem.Headers.ContentDisposition =
+                new ContentDispositionHeaderValue(Constants.HttpContent.Disposition.Types.FormData)
+                {
+                    Name = Constants.Gotenberg.SharedFormFieldNames.Files, FileName = item.Key
+                };
+
+            contentItem.Headers.ContentType = new MediaTypeHeaderValue(Constants.HttpContent.MediaTypes.ApplicationPdf);
+
+            yield return contentItem;
+        }
+
+        foreach (var item in this.Config.IfNullEmptyContent())
+            yield return item;
+
+        foreach (var content in base.ToHttpContent())
+            yield return content;
+    }
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/ReadMetadataRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/ReadMetadataRequest.cs
@@ -1,0 +1,14 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+/// <summary>
+/// Reads metadata from PDF files. Returns JSON keyed by filename.
+/// </summary>
+public sealed class ReadMetadataRequest : PdfEngineRequest
+{
+    protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.ReadMetadata;
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/RotatePdfRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/RotatePdfRequest.cs
@@ -1,0 +1,36 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0
+
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+public sealed class RotatePdfRequest : PdfEngineRequest
+{
+    protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.Rotate;
+
+    public RotationAngle? RotateAngle { get; set; }
+
+    public PageRanges? RotatePages { get; set; }
+
+    protected override void Validate()
+    {
+        if (this.RotateAngle == null)
+            throw new InvalidOperationException("Rotation angle is required.");
+
+        base.Validate();
+    }
+
+    protected override IEnumerable<HttpContent> ToHttpContent()
+    {
+        yield return CreateFormDataItem(this.RotateAngle!, "rotateAngle");
+
+        if (this.RotatePages != null)
+            yield return CreateFormDataItem(this.RotatePages.Value, "rotatePages");
+
+        foreach (var content in base.ToHttpContent())
+            yield return content;
+    }
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/SplitPdfRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/SplitPdfRequest.cs
@@ -1,0 +1,41 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0
+
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+public sealed class SplitPdfRequest : PdfEngineRequest
+{
+    protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.Split;
+
+    public SplitMode? Mode { get; set; }
+
+    public string? Span { get; set; }
+
+    public bool? Unify { get; set; }
+
+    protected override void Validate()
+    {
+        if (this.Mode == null)
+            throw new InvalidOperationException("Split mode is required.");
+        if (string.IsNullOrWhiteSpace(this.Span))
+            throw new InvalidOperationException("Split span is required.");
+
+        base.Validate();
+    }
+
+    protected override IEnumerable<HttpContent> ToHttpContent()
+    {
+        yield return CreateFormDataItem(this.Mode!.Value.ToFormValue(), "splitMode");
+        yield return CreateFormDataItem(this.Span!, "splitSpan");
+
+        if (this.Unify == true)
+            yield return CreateFormDataItem("true", "splitUnify");
+
+        foreach (var content in base.ToHttpContent())
+            yield return content;
+    }
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/WriteMetadataRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/WriteMetadataRequest.cs
@@ -1,0 +1,41 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0
+
+using Newtonsoft.Json.Linq;
+
+namespace Gotenberg.Sharp.API.Client.Domain.Requests;
+
+/// <summary>
+/// Writes metadata to PDF files.
+/// </summary>
+public sealed class WriteMetadataRequest : PdfEngineRequest
+{
+    protected override string ApiPath => Constants.Gotenberg.PdfEngines.ApiPaths.WriteMetadata;
+
+    public JObject? Metadata { get; set; }
+
+    protected override void Validate()
+    {
+        if (this.Metadata == null)
+            throw new InvalidOperationException("Metadata is required.");
+
+        base.Validate();
+    }
+
+    protected override IEnumerable<HttpContent> ToHttpContent()
+    {
+        var metadataContent = new StringContent(this.Metadata!.ToString());
+        metadataContent.Headers.ContentType = new MediaTypeHeaderValue(Constants.HttpContent.MediaTypes.TextHtml);
+        metadataContent.Headers.ContentDisposition =
+            new ContentDispositionHeaderValue(Constants.HttpContent.Disposition.Types.FormData)
+            {
+                Name = "metadata"
+            };
+        yield return metadataContent;
+
+        foreach (var content in base.ToHttpContent())
+            yield return content;
+    }
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/Requests/WriteMetadataRequest.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/Requests/WriteMetadataRequest.cs
@@ -27,7 +27,7 @@ public sealed class WriteMetadataRequest : PdfEngineRequest
     protected override IEnumerable<HttpContent> ToHttpContent()
     {
         var metadataContent = new StringContent(this.Metadata!.ToString());
-        metadataContent.Headers.ContentType = new MediaTypeHeaderValue(Constants.HttpContent.MediaTypes.TextHtml);
+        metadataContent.Headers.ContentType = new MediaTypeHeaderValue(Constants.HttpContent.MediaTypes.ApplicationJson);
         metadataContent.Headers.ContentDisposition =
             new ContentDispositionHeaderValue(Constants.HttpContent.Disposition.Types.FormData)
             {

--- a/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PageRanges.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PageRanges.cs
@@ -51,6 +51,33 @@ public sealed class PageRanges : IEquatable<PageRanges>
                 $"Invalid page range format: '{ranges}'. Expected format: '1-3,5,8-10'.",
                 nameof(ranges));
 
+        // Semantic validation: verify page numbers are >= 1 and range start <= end
+        foreach (var segment in trimmed.Split(','))
+        {
+            var parts = segment.Trim().Split('-');
+            if (parts.Length == 1)
+            {
+                var page = int.Parse(parts[0].Trim());
+                if (page < 1)
+                    throw new ArgumentException(
+                        $"Page number must be >= 1, but got {page} in '{ranges}'.",
+                        nameof(ranges));
+            }
+            else if (parts.Length == 2)
+            {
+                var start = int.Parse(parts[0].Trim());
+                var end = int.Parse(parts[1].Trim());
+                if (start < 1 || end < 1)
+                    throw new ArgumentException(
+                        $"Page numbers must be >= 1, but got range '{start}-{end}' in '{ranges}'.",
+                        nameof(ranges));
+                if (start > end)
+                    throw new ArgumentException(
+                        $"Range start must be <= end, but got '{start}-{end}' in '{ranges}'.",
+                        nameof(ranges));
+            }
+        }
+
         return new PageRanges(trimmed);
     }
 

--- a/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PageRanges.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/PageRanges.cs
@@ -1,0 +1,70 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System.Text.RegularExpressions;
+
+namespace Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+/// <summary>
+/// Represents validated page ranges in the format "1-3,5,8-10".
+/// Used for watermark, stamp, rotation, and split page targeting.
+/// </summary>
+public sealed class PageRanges : IEquatable<PageRanges>
+{
+    private static readonly Regex ValidPattern = new(
+        @"^\s*\d+(\s*-\s*\d+)?(\s*,\s*\d+(\s*-\s*\d+)?)*\s*$",
+        RegexOptions.Compiled);
+
+    public string Value { get; }
+
+    private PageRanges(string value)
+    {
+        Value = value;
+    }
+
+    /// <summary>
+    /// Creates validated page ranges.
+    /// </summary>
+    /// <param name="ranges">Page range string (e.g., "1-3", "5", "1-3,5,8-10").</param>
+    /// <exception cref="ArgumentException">Thrown when format is invalid.</exception>
+    public static PageRanges Create(string ranges)
+    {
+        if (string.IsNullOrWhiteSpace(ranges))
+            throw new ArgumentException("Page ranges must not be null or empty.", nameof(ranges));
+
+        var trimmed = ranges.Trim();
+
+        if (!ValidPattern.IsMatch(trimmed))
+            throw new ArgumentException(
+                $"Invalid page range format: '{ranges}'. Expected format: '1-3,5,8-10'.",
+                nameof(ranges));
+
+        return new PageRanges(trimmed);
+    }
+
+    public override string ToString() => Value;
+
+    public bool Equals(PageRanges? other) => other is not null && Value == other.Value;
+
+    public override bool Equals(object? obj) => Equals(obj as PageRanges);
+
+    public override int GetHashCode() => Value.GetHashCode();
+
+    public static implicit operator string(PageRanges ranges) => ranges.Value;
+
+    public static bool operator ==(PageRanges? left, PageRanges? right) => Equals(left, right);
+
+    public static bool operator !=(PageRanges? left, PageRanges? right) => !Equals(left, right);
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/RotationAngle.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/RotationAngle.cs
@@ -1,0 +1,61 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+using System.Globalization;
+
+namespace Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+/// <summary>
+/// Represents a validated PDF rotation angle. Only 90, 180, and 270 degrees are valid.
+/// </summary>
+public sealed class RotationAngle : IEquatable<RotationAngle>
+{
+    private static readonly int[] ValidAngles = { 90, 180, 270 };
+
+    public int Value { get; }
+
+    private RotationAngle(int value)
+    {
+        Value = value;
+    }
+
+    public static RotationAngle Create(int angle)
+    {
+        if (Array.IndexOf(ValidAngles, angle) < 0)
+            throw new ArgumentException(
+                $"Rotation angle must be one of: {string.Join(", ", ValidAngles)}. Got: {angle}.",
+                nameof(angle));
+
+        return new RotationAngle(angle);
+    }
+
+    public static RotationAngle Degrees90 => new(90);
+    public static RotationAngle Degrees180 => new(180);
+    public static RotationAngle Degrees270 => new(270);
+
+    public override string ToString() => Value.ToString(CultureInfo.InvariantCulture);
+
+    public bool Equals(RotationAngle? other) => other is not null && Value == other.Value;
+
+    public override bool Equals(object? obj) => Equals(obj as RotationAngle);
+
+    public override int GetHashCode() => Value;
+
+    public static implicit operator int(RotationAngle angle) => angle.Value;
+
+    public static bool operator ==(RotationAngle? left, RotationAngle? right) => Equals(left, right);
+
+    public static bool operator !=(RotationAngle? left, RotationAngle? right) => !Equals(left, right);
+}

--- a/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/SplitMode.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Domain/ValueObjects/SplitMode.cs
@@ -1,0 +1,42 @@
+// Copyright 2019-2026 Chris Mohan, Jaben Cargman
+//  and GotenbergSharpApiClient Contributors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+namespace Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+
+/// <summary>
+/// Represents the split mode for PDF splitting operations.
+/// </summary>
+public enum SplitMode
+{
+    /// <summary>
+    /// Split into chunks of N pages each.
+    /// </summary>
+    Intervals,
+
+    /// <summary>
+    /// Extract specific page ranges.
+    /// </summary>
+    Pages
+}
+
+internal static class SplitModeExtensions
+{
+    internal static string ToFormValue(this SplitMode mode) => mode switch
+    {
+        SplitMode.Intervals => "intervals",
+        SplitMode.Pages => "pages",
+        _ => throw new ArgumentOutOfRangeException(nameof(mode))
+    };
+}

--- a/src/Gotenberg.Sharp.Api.Client/GotenbergSharpClient.cs
+++ b/src/Gotenberg.Sharp.Api.Client/GotenbergSharpClient.cs
@@ -243,6 +243,56 @@ public class GotenbergSharpClient
     }
 
     /// <summary>
+    /// Executes a standalone PDF engine operation (flatten, rotate, split, encrypt, metadata).
+    /// </summary>
+    public virtual Task<Stream> ExecutePdfEngineAsync(
+        PdfEngineRequest request,
+        CancellationToken cancelToken = default)
+    {
+        if (request == null) throw new ArgumentNullException(nameof(request));
+
+        return this.ExecuteRequestAsync(request.CreateApiRequest(), cancelToken);
+    }
+
+    /// <summary>
+    /// Executes a standalone PDF engine operation using a builder.
+    /// </summary>
+    public virtual async Task<Stream> ExecutePdfEngineAsync<TRequest>(
+        PdfEngineBuilder<TRequest> builder,
+        CancellationToken cancelToken = default)
+        where TRequest : PdfEngineRequest
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        var request = await builder.BuildAsync().ConfigureAwait(false);
+
+        return await this.ExecutePdfEngineAsync(request, cancelToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Reads metadata from PDF files. Returns JSON string keyed by filename.
+    /// </summary>
+    public virtual async Task<string> ReadPdfMetadataAsync(
+        PdfEngineBuilder<ReadMetadataRequest> builder,
+        CancellationToken cancelToken = default)
+    {
+        if (builder == null) throw new ArgumentNullException(nameof(builder));
+
+        var request = await builder.BuildAsync().ConfigureAwait(false);
+
+        using var response = await this.SendRequestAsync(
+            request.CreateApiRequest(),
+            HttpCompletionOption.ResponseContentRead,
+            cancelToken);
+
+#if NET5_0_OR_GREATER
+        return await response.Content.ReadAsStringAsync(cancelToken);
+#else
+        return await response.Content.ReadAsStringAsync();
+#endif
+    }
+
+    /// <summary>
     /// Gets the current version of Gotenberg.
     /// Custom variants of Gotenberg may not print a strict semver version.
     /// For instance, the live demo prints 8.17.0-live-demo-snapshot.

--- a/src/Gotenberg.Sharp.Api.Client/Infrastructure/Constants.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Infrastructure/Constants.cs
@@ -156,6 +156,22 @@ public static class Constants
                 public const string MergePdf = $"{Root}/merge";
 
                 public const string ConvertPdf = $"{Root}/convert";
+
+                public const string Flatten = $"{Root}/flatten";
+
+                public const string Rotate = $"{Root}/rotate";
+
+                public const string Split = $"{Root}/split";
+
+                public const string Encrypt = $"{Root}/encrypt";
+
+                public const string ReadMetadata = $"{Root}/metadata/read";
+
+                public const string WriteMetadata = $"{Root}/metadata/write";
+
+                public const string Watermark = $"{Root}/watermark";
+
+                public const string Stamp = $"{Root}/stamp";
             }
 
             public static class Routes

--- a/src/Gotenberg.Sharp.Api.Client/Infrastructure/Constants.cs
+++ b/src/Gotenberg.Sharp.Api.Client/Infrastructure/Constants.cs
@@ -32,6 +32,8 @@ public static class Constants
             public const string TextHtml = "text/html";
 
             public const string ApplicationPdf = "application/pdf";
+
+            public const string ApplicationJson = "application/json";
         }
 
         public static class MultipartData

--- a/test/GotenbergSharpClient.Tests/PdfEngineOperationsTests.cs
+++ b/test/GotenbergSharpClient.Tests/PdfEngineOperationsTests.cs
@@ -113,6 +113,7 @@ public class PdfEngineOperationsTests
 
     #region Integration Tests
 
+    [Category("Integration")]
     [Test]
     public async Task FlattenPdf_Succeeds()
     {
@@ -128,6 +129,7 @@ public class PdfEngineOperationsTests
         result.Length.Should().BeGreaterThan(0);
     }
 
+    [Category("Integration")]
     [Test]
     public async Task RotatePdf_Succeeds()
     {
@@ -143,6 +145,7 @@ public class PdfEngineOperationsTests
         result.Length.Should().BeGreaterThan(0);
     }
 
+    [Category("Integration")]
     [Test]
     public async Task EncryptPdf_Succeeds()
     {
@@ -158,6 +161,7 @@ public class PdfEngineOperationsTests
         result.Length.Should().BeGreaterThan(0);
     }
 
+    [Category("Integration")]
     [Test]
     public async Task WriteMetadata_Succeeds()
     {
@@ -177,6 +181,7 @@ public class PdfEngineOperationsTests
         result.Length.Should().BeGreaterThan(0);
     }
 
+    [Category("Integration")]
     [Test]
     public async Task ReadMetadata_ReturnsJson()
     {

--- a/test/GotenbergSharpClient.Tests/PdfEngineOperationsTests.cs
+++ b/test/GotenbergSharpClient.Tests/PdfEngineOperationsTests.cs
@@ -1,0 +1,224 @@
+using Gotenberg.Sharp.API.Client.Domain.Builders;
+using Gotenberg.Sharp.API.Client.Domain.Requests;
+using Gotenberg.Sharp.API.Client.Domain.Settings;
+using Gotenberg.Sharp.API.Client.Domain.ValueObjects;
+using Gotenberg.Sharp.API.Client.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Linq;
+
+namespace GotenbergSharpClient.Tests;
+
+[TestFixture]
+public class PdfEngineOperationsTests
+{
+    #region Builder Factory Tests
+
+    [Test]
+    public void PdfEngineBuilders_Flatten_CreatesRequest()
+    {
+        var builder = PdfEngineBuilders.Flatten()
+            .WithPdfs(a => a.AddItem("test.pdf", new byte[] { 1, 2, 3 }));
+
+        var request = builder.Build();
+
+        request.Should().BeOfType<FlattenPdfRequest>();
+    }
+
+    [Test]
+    public void PdfEngineBuilders_Rotate_CreatesRequest()
+    {
+        var builder = PdfEngineBuilders.Rotate(90)
+            .WithPdfs(a => a.AddItem("test.pdf", new byte[] { 1, 2, 3 }));
+
+        var request = builder.Build();
+
+        request.Should().BeOfType<RotatePdfRequest>();
+        ((RotatePdfRequest)request).RotateAngle!.Value.Should().Be(90);
+    }
+
+    [Test]
+    public void PdfEngineBuilders_Rotate_WithPages_CreatesRequest()
+    {
+        var builder = PdfEngineBuilders.Rotate(180, "1-3")
+            .WithPdfs(a => a.AddItem("test.pdf", new byte[] { 1, 2, 3 }));
+
+        var request = builder.Build();
+
+        var rotateRequest = (RotatePdfRequest)request;
+        rotateRequest.RotateAngle!.Value.Should().Be(180);
+        rotateRequest.RotatePages!.Value.Should().Be("1-3");
+    }
+
+    [Test]
+    public void PdfEngineBuilders_Split_CreatesRequest()
+    {
+        var builder = PdfEngineBuilders.Split(SplitMode.Intervals, "2")
+            .WithPdfs(a => a.AddItem("test.pdf", new byte[] { 1, 2, 3 }));
+
+        var request = builder.Build();
+
+        var splitRequest = (SplitPdfRequest)request;
+        splitRequest.Mode.Should().Be(SplitMode.Intervals);
+        splitRequest.Span.Should().Be("2");
+    }
+
+    [Test]
+    public void PdfEngineBuilders_Encrypt_CreatesRequest()
+    {
+        var builder = PdfEngineBuilders.Encrypt("user123", "owner456")
+            .WithPdfs(a => a.AddItem("test.pdf", new byte[] { 1, 2, 3 }));
+
+        var request = builder.Build();
+
+        var encryptRequest = (EncryptPdfRequest)request;
+        encryptRequest.UserPassword.Should().Be("user123");
+        encryptRequest.OwnerPassword.Should().Be("owner456");
+    }
+
+    [Test]
+    public void PdfEngineBuilders_WriteMetadata_CreatesRequest()
+    {
+        var metadata = new Dictionary<string, object>
+        {
+            { "Author", "Test" },
+            { "Title", "Test Doc" }
+        };
+
+        var builder = PdfEngineBuilders.WriteMetadata(metadata)
+            .WithPdfs(a => a.AddItem("test.pdf", new byte[] { 1, 2, 3 }));
+
+        var request = builder.Build();
+
+        var writeRequest = (WriteMetadataRequest)request;
+        writeRequest.Metadata!["Author"]!.Value<string>().Should().Be("Test");
+    }
+
+    [Test]
+    public void PdfEngineBuilders_Rotate_WithInvalidAngle_Throws()
+    {
+        var act = () => PdfEngineBuilders.Rotate(45);
+
+        act.Should().ThrowExactly<ArgumentException>();
+    }
+
+    [Test]
+    public void PdfEngineBuilders_Encrypt_WithEmptyPassword_Throws()
+    {
+        var act = () => PdfEngineBuilders.Encrypt("");
+
+        act.Should().ThrowExactly<ArgumentException>();
+    }
+
+    #endregion
+
+    #region Integration Tests
+
+    [Test]
+    public async Task FlattenPdf_Succeeds()
+    {
+        var client = CreateAuthenticatedClient();
+        var pdfBytes = await GenerateTestPdf(client);
+
+        var builder = PdfEngineBuilders.Flatten()
+            .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
+
+        var result = await client.ExecutePdfEngineAsync(builder);
+
+        result.Should().NotBeNull();
+        result.Length.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task RotatePdf_Succeeds()
+    {
+        var client = CreateAuthenticatedClient();
+        var pdfBytes = await GenerateTestPdf(client);
+
+        var builder = PdfEngineBuilders.Rotate(90)
+            .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
+
+        var result = await client.ExecutePdfEngineAsync(builder);
+
+        result.Should().NotBeNull();
+        result.Length.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task EncryptPdf_Succeeds()
+    {
+        var client = CreateAuthenticatedClient();
+        var pdfBytes = await GenerateTestPdf(client);
+
+        var builder = PdfEngineBuilders.Encrypt("user123", "owner456")
+            .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
+
+        var result = await client.ExecutePdfEngineAsync(builder);
+
+        result.Should().NotBeNull();
+        result.Length.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task WriteMetadata_Succeeds()
+    {
+        var client = CreateAuthenticatedClient();
+        var pdfBytes = await GenerateTestPdf(client);
+
+        var builder = PdfEngineBuilders.WriteMetadata(new Dictionary<string, object>
+            {
+                { "Author", "GotenbergSharpApiClient" },
+                { "Title", "Test Document" }
+            })
+            .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
+
+        var result = await client.ExecutePdfEngineAsync(builder);
+
+        result.Should().NotBeNull();
+        result.Length.Should().BeGreaterThan(0);
+    }
+
+    [Test]
+    public async Task ReadMetadata_ReturnsJson()
+    {
+        var client = CreateAuthenticatedClient();
+        var pdfBytes = await GenerateTestPdf(client);
+
+        var builder = PdfEngineBuilders.ReadMetadata()
+            .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
+
+        var json = await client.ReadPdfMetadataAsync(builder);
+
+        json.Should().NotBeNullOrEmpty();
+        var parsed = JObject.Parse(json);
+        parsed.Should().NotBeEmpty();
+    }
+
+    #endregion
+
+    private static Gotenberg.Sharp.API.Client.GotenbergSharpClient CreateAuthenticatedClient()
+    {
+        var services = new ServiceCollection();
+        services.AddOptions<GotenbergSharpClientOptions>()
+            .Configure(options =>
+            {
+                options.ServiceUrl = new Uri("http://localhost:3000");
+                options.BasicAuthUsername = "testuser";
+                options.BasicAuthPassword = "testpass";
+            });
+        services.AddGotenbergSharpClient();
+        return services.BuildServiceProvider()
+            .GetRequiredService<Gotenberg.Sharp.API.Client.GotenbergSharpClient>();
+    }
+
+    private static async Task<byte[]> GenerateTestPdf(Gotenberg.Sharp.API.Client.GotenbergSharpClient client)
+    {
+        var builder = new HtmlRequestBuilder()
+            .AddDocument(doc => doc.SetBody("<html><body><h1>Test PDF</h1></body></html>"));
+
+        var stream = await client.HtmlToPdfAsync(builder);
+
+        using var ms = new MemoryStream();
+        await stream.CopyToAsync(ms);
+        return ms.ToArray();
+    }
+}

--- a/test/GotenbergSharpClient.Tests/PdfEngineOperationsTests.cs
+++ b/test/GotenbergSharpClient.Tests/PdfEngineOperationsTests.cs
@@ -123,7 +123,7 @@ public class PdfEngineOperationsTests
         var builder = PdfEngineBuilders.Flatten()
             .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
 
-        var result = await client.ExecutePdfEngineAsync(builder);
+        using var result = await client.ExecutePdfEngineAsync(builder);
 
         result.Should().NotBeNull();
         result.Length.Should().BeGreaterThan(0);
@@ -139,7 +139,7 @@ public class PdfEngineOperationsTests
         var builder = PdfEngineBuilders.Rotate(90)
             .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
 
-        var result = await client.ExecutePdfEngineAsync(builder);
+        using var result = await client.ExecutePdfEngineAsync(builder);
 
         result.Should().NotBeNull();
         result.Length.Should().BeGreaterThan(0);
@@ -155,7 +155,7 @@ public class PdfEngineOperationsTests
         var builder = PdfEngineBuilders.Encrypt("user123", "owner456")
             .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
 
-        var result = await client.ExecutePdfEngineAsync(builder);
+        using var result = await client.ExecutePdfEngineAsync(builder);
 
         result.Should().NotBeNull();
         result.Length.Should().BeGreaterThan(0);
@@ -175,7 +175,7 @@ public class PdfEngineOperationsTests
             })
             .WithPdfs(a => a.AddItem("test.pdf", pdfBytes));
 
-        var result = await client.ExecutePdfEngineAsync(builder);
+        using var result = await client.ExecutePdfEngineAsync(builder);
 
         result.Should().NotBeNull();
         result.Length.Should().BeGreaterThan(0);
@@ -220,7 +220,7 @@ public class PdfEngineOperationsTests
         var builder = new HtmlRequestBuilder()
             .AddDocument(doc => doc.SetBody("<html><body><h1>Test PDF</h1></body></html>"));
 
-        var stream = await client.HtmlToPdfAsync(builder);
+        using var stream = await client.HtmlToPdfAsync(builder);
 
         using var ms = new MemoryStream();
         await stream.CopyToAsync(ms);


### PR DESCRIPTION
## Summary
- New `PdfEngineRequest` base class with concrete types: `FlattenPdfRequest`, `RotatePdfRequest`, `SplitPdfRequest`, `EncryptPdfRequest`, `ReadMetadataRequest`, `WriteMetadataRequest`
- `PdfEngineBuilders` static factory with fluent creation: `Flatten()`, `Rotate(90)`, `Split(mode, span)`, `Encrypt(user, owner)`, `ReadMetadata()`, `WriteMetadata(dict)`
- Add `ExecutePdfEngineAsync` and `ReadPdfMetadataAsync` (returns JSON string) to `GotenbergSharpClient`
- API paths: `/forms/pdfengines/flatten`, `/rotate`, `/split`, `/encrypt`, `/metadata/read`, `/metadata/write`, `/watermark`, `/stamp`

## Test plan
- [x] 13 tests covering builder factories, validation, and integration
- [x] 5 integration tests: flatten, rotate, encrypt, write metadata, read metadata (returns parsed JSON)
- [x] PdfEngineOperations example console app added
- [x] README section with usage for all operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for standalone PDF engine operations: Flatten, Rotate, Split, Encrypt, and Metadata Read/Write functionality.
  * Introduced new API methods for executing PDF engine operations with builder pattern support.
  * Released new example project demonstrating practical usage of PDF engine operations.

* **Documentation**
  * Enhanced README with detailed code examples and guide for using PDF engine operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->